### PR TITLE
Add tabbed HomeScreen and route through Job tab

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,6 @@
 // lib/main.dart
 import 'package:flutter/material.dart';
-import 'core/models.dart';
-import 'ui/new_job_screen.dart';
-import 'data/repo_factory.dart';
-import 'data/repo.dart';
+import 'ui/home_screen.dart';
 
 void main() => runApp(const BomApp());
 
@@ -14,68 +11,7 @@ class BomApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Entrypoint(),
-    );
-  }
-}
-
-class Entrypoint extends StatefulWidget {
-  const Entrypoint({super.key});
-  @override
-  State<Entrypoint> createState() => _EntrypointState();
-}
-
-class _EntrypointState extends State<Entrypoint> {
-  late final StandardsRepo repo;
-  Future<List<StandardDef>>? _future;
-
-  @override
-  void initState() {
-    super.initState();
-    repo = createRepo();
-    _future = _loadOrSeed();
-  }
-
-  Future<List<StandardDef>> _loadOrSeed() async {
-    var list = await repo.listStandards();
-    if (list.isEmpty) {
-      // Seed FS12 once on first run for the current platform backend.
-      final std = StandardDef(
-        code: 'FS12',
-        name: 'Framing Standard 12',
-        parameters: [ParameterDef(key: 'PoleHeight', type: ParamType.number)],
-        staticComponents: [StaticComponent(mm: 'MM#BRACE-STD', qty: 2)],
-        dynamicComponents: [
-          DynamicComponentDef(name: 'Primary Connector', rules: [
-            RuleDef(expr: {">=": [ {"var":"PoleHeight"}, 40 ]}, outputs: [OutputSpec(mm: "MM#PC-40", qty: 1)]),
-            RuleDef(expr: {"<":  [ {"var":"PoleHeight"}, 40 ]}, outputs: [OutputSpec(mm: "MM#PC-35", qty: 1)]),
-          ])
-        ],
-      );
-      await repo.saveStandard(std);
-      list = await repo.listStandards();
-    }
-    return list;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<List<StandardDef>>(
-      future: _future,
-      builder: (context, snap) {
-        if (snap.connectionState != ConnectionState.done) {
-          return const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
-          );
-        }
-        if (snap.hasError) {
-          return Scaffold(
-            body: Center(child: Text('Load error: ${snap.error}')),
-          );
-        }
-        final standards = snap.data ?? const <StandardDef>[];
-        return NewJobScreen(standards: standards);
-      },
+      home: HomeScreen(),
     );
   }
 }

--- a/lib/ui/home_screen.dart
+++ b/lib/ui/home_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import '../core/models.dart';
+import '../data/repo.dart';
+import '../data/repo_factory.dart';
+import 'new_job_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('BOM Builder'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Job'),
+              Tab(text: 'Standards'),
+              Tab(text: 'Approvals'),
+              Tab(text: 'Aliases'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            _JobTab(),
+            Center(child: Text('Standards')),
+            Center(child: Text('Approvals')),
+            Center(child: Text('Aliases')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _JobTab extends StatefulWidget {
+  const _JobTab();
+
+  @override
+  State<_JobTab> createState() => _JobTabState();
+}
+
+class _JobTabState extends State<_JobTab> {
+  late final StandardsRepo repo;
+  Future<List<StandardDef>>? _future;
+
+  @override
+  void initState() {
+    super.initState();
+    repo = createRepo();
+    _future = _loadOrSeed();
+  }
+
+  Future<List<StandardDef>> _loadOrSeed() async {
+    var list = await repo.listStandards();
+    if (list.isEmpty) {
+      // Seed FS12 once on first run for the current platform backend.
+      final std = StandardDef(
+        code: 'FS12',
+        name: 'Framing Standard 12',
+        parameters: [ParameterDef(key: 'PoleHeight', type: ParamType.number)],
+        staticComponents: [StaticComponent(mm: 'MM#BRACE-STD', qty: 2)],
+        dynamicComponents: [
+          DynamicComponentDef(name: 'Primary Connector', rules: [
+            RuleDef(expr: {'>=': [ {'var': 'PoleHeight'}, 40 ]}, outputs: [OutputSpec(mm: 'MM#PC-40', qty: 1)]),
+            RuleDef(expr: {'<':  [ {'var': 'PoleHeight'}, 40 ]}, outputs: [OutputSpec(mm: 'MM#PC-35', qty: 1)]),
+          ])
+        ],
+      );
+      await repo.saveStandard(std);
+      list = await repo.listStandards();
+    }
+    return list;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<StandardDef>>(
+      future: _future,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snap.hasError) {
+          return Center(child: Text('Load error: ${snap.error}'));
+        }
+        final standards = snap.data ?? const <StandardDef>[];
+        return NewJobScreen(standards: standards);
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add HomeScreen with DefaultTabController and four tabs
- Load standards and embed NewJobScreen in Job tab
- Update main.dart to launch HomeScreen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c1821f44b483269ca5acf9584ffea0