### PR TITLE
Add widget test for standards manager screen

### DIFF
--- a/test/standards_manager_screen_test.dart
+++ b/test/standards_manager_screen_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bom_builder/ui/standards_manager_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('standards_manager_test');
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+        return tempDir.path;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    channel.setMockMethodCallHandler(null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('renders Standards manager screen title', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: StandardsManagerScreen()));
+    await tester.pumpAndSettle();
+    expect(find.text('Standards'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a widget test that pumps `StandardsManagerScreen` and verifies the title

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c1911a030c8326ad4340bd62f33ac9