### PR TITLE
Add desktop build script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # flutter_bom
 
 A new Flutter project.
+
+## Building a standalone executable
+
+1. Install Flutter and ensure the tool works:
+   ```bash
+   git clone https://github.com/flutter/flutter.git -b stable
+   export PATH="\$PATH:`pwd`/flutter/bin"
+   flutter doctor
+   ```
+2. Run the project's tests:
+   ```bash
+   flutter test
+   ```
+3. Build the release executable for your platform:
+   ```bash
+   ./scripts/build_release.sh windows
+   ```
+   Replace `windows` with `linux` or `macos` as needed. The output will be placed in `build/<platform>/`.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Builds a desktop executable for the specified platform.
+# Usage: ./scripts/build_release.sh [windows|linux|macos]
+set -e
+platform="$1"
+if [[ -z "$platform" ]]; then
+  echo "Usage: build_release.sh [windows|linux|macos]" >&2
+  exit 1
+fi
+case "$platform" in
+  windows|linux|macos)
+    flutter build "$platform" --release
+    echo "Build complete. Check build/$platform/ for the executable."
+    ;;
+  *)
+    echo "Unsupported platform: $platform" >&2
+    exit 1
+    ;;
+esac
+


### PR DESCRIPTION
## Summary
- document how to install Flutter, run tests, and build a release executable
- add `build_release.sh` script to build a desktop binary for Windows/Linux/macOS

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ac2f4b4c8326a908991deea02f11