### PR TITLE
Add explicit save actions and test local repo persistence

### DIFF
--- a/lib/ui/rule_wizard.dart
+++ b/lib/ui/rule_wizard.dart
@@ -177,12 +177,15 @@ class _RuleWizardState extends State<RuleWizard> {
                       onChanged: (v) {
                         if (v != null) setState(() => type = v);
                       },
-                      items: ParamType.values
-                          .map((e) => DropdownMenuItem(
-                                value: e,
-                                child: Text(paramTypeToString(e)),
-                              ))
-                          .toList(),
+                      items:
+                          ParamType.values
+                              .map(
+                                (e) => DropdownMenuItem(
+                                  value: e,
+                                  child: Text(paramTypeToString(e)),
+                                ),
+                              )
+                              .toList(),
                     ),
                     const SizedBox(height: 8),
                     TextField(
@@ -200,8 +203,8 @@ class _RuleWizardState extends State<RuleWizard> {
                       children: [
                         Checkbox(
                           value: requiredField,
-                          onChanged: (v) =>
-                              setState(() => requiredField = v ?? false),
+                          onChanged:
+                              (v) => setState(() => requiredField = v ?? false),
                         ),
                         const Text('Required'),
                       ],
@@ -221,14 +224,16 @@ class _RuleWizardState extends State<RuleWizard> {
                       ParameterDef(
                         key: keyCtrl.text.trim(),
                         type: type,
-                        unit: unitCtrl.text.trim().isEmpty
-                            ? null
-                            : unitCtrl.text.trim(),
-                        allowedValues: allowedCtrl.text
-                            .split(',')
-                            .map((e) => e.trim())
-                            .where((e) => e.isNotEmpty)
-                            .toList(),
+                        unit:
+                            unitCtrl.text.trim().isEmpty
+                                ? null
+                                : unitCtrl.text.trim(),
+                        allowedValues:
+                            allowedCtrl.text
+                                .split(',')
+                                .map((e) => e.trim())
+                                .where((e) => e.isNotEmpty)
+                                .toList(),
                         required: requiredField,
                       ),
                     );
@@ -299,13 +304,19 @@ class _RuleWizardState extends State<RuleWizard> {
               optionsBuilder: (TextEditingValue textEditingValue) {
                 return widget.parameters
                     .map((e) => e.key)
-                    .where((k) => k
-                        .toLowerCase()
-                        .contains(textEditingValue.text.toLowerCase()));
+                    .where(
+                      (k) => k.toLowerCase().contains(
+                        textEditingValue.text.toLowerCase(),
+                      ),
+                    );
               },
               initialValue: TextEditingValue(text: f.param.text),
-              fieldViewBuilder:
-                  (context, controller, focusNode, onFieldSubmitted) {
+              fieldViewBuilder: (
+                context,
+                controller,
+                focusNode,
+                onFieldSubmitted,
+              ) {
                 controller.text = f.param.text;
                 return TextField(
                   controller: controller,
@@ -320,8 +331,8 @@ class _RuleWizardState extends State<RuleWizard> {
             ),
           ),
           IconButton(
-            onPressed: () =>
-                _addParameterDialog(initialKey: f.param.text.trim()),
+            onPressed:
+                () => _addParameterDialog(initialKey: f.param.text.trim()),
             icon: const Icon(Icons.add),
             tooltip: 'Add variable',
           ),
@@ -456,9 +467,10 @@ class _RuleWizardState extends State<RuleWizard> {
             const SizedBox(height: 4),
             Wrap(
               spacing: 8,
-              children: widget.parameters
-                  .map((e) => Chip(label: Text(e.key)))
-                  .toList(),
+              children:
+                  widget.parameters
+                      .map((e) => Chip(label: Text(e.key)))
+                      .toList(),
             ),
             TextButton.icon(
               onPressed: _addParameterDialog,
@@ -493,6 +505,10 @@ class _RuleWizardState extends State<RuleWizard> {
             ),
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _save,
+        child: const Icon(Icons.save),
       ),
     );
   }

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -87,10 +87,11 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
     try {
       final updated = await Navigator.of(context).push<DynamicComponentDef>(
         MaterialPageRoute(
-          builder: (_) => RuleWizard(
-            parent: dynamicComponents[index],
-            parameters: parameters,
-          ),
+          builder:
+              (_) => RuleWizard(
+                parent: dynamicComponents[index],
+                parameters: parameters,
+              ),
         ),
       );
       setState(() {
@@ -100,8 +101,9 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
         // ensure UI reflects any parameter changes made inside the wizard
       });
     } catch (e) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Edit error: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Edit error: $e')));
     }
   }
 
@@ -136,8 +138,9 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       if (!mounted) return;
       Navigator.of(context).pop(true);
     } catch (e) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Save error: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Save error: $e')));
     }
   }
 
@@ -175,19 +178,22 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                 .map(
                   (e) => _ParameterEditor(
                     def: e.value,
-                    onChanged: (p) => setState(() {
-                      parameters[e.key] = p;
-                    }),
-                    onDelete: () => setState(() {
-                      parameters.removeAt(e.key);
-                    }),
+                    onChanged:
+                        (p) => setState(() {
+                          parameters[e.key] = p;
+                        }),
+                    onDelete:
+                        () => setState(() {
+                          parameters.removeAt(e.key);
+                        }),
                   ),
                 )
                 .toList(),
             TextButton.icon(
-              onPressed: () => setState(() {
-                parameters.add(ParameterDef(key: '', type: ParamType.text));
-              }),
+              onPressed:
+                  () => setState(() {
+                    parameters.add(ParameterDef(key: '', type: ParamType.text));
+                  }),
               icon: const Icon(Icons.add),
               label: const Text('Add Parameter'),
             ),
@@ -200,19 +206,22 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                 .map(
                   (e) => _StaticEditor(
                     comp: e.value,
-                    onChanged: (c) => setState(() {
-                      staticComponents[e.key] = c;
-                    }),
-                    onDelete: () => setState(() {
-                      staticComponents.removeAt(e.key);
-                    }),
+                    onChanged:
+                        (c) => setState(() {
+                          staticComponents[e.key] = c;
+                        }),
+                    onDelete:
+                        () => setState(() {
+                          staticComponents.removeAt(e.key);
+                        }),
                   ),
                 )
                 .toList(),
             TextButton.icon(
-              onPressed: () => setState(() {
-                staticComponents.add(StaticComponent(mm: '', qty: 1));
-              }),
+              onPressed:
+                  () => setState(() {
+                    staticComponents.add(StaticComponent(mm: '', qty: 1));
+                  }),
               icon: const Icon(Icons.add),
               label: const Text('Add Static Component'),
             ),
@@ -225,30 +234,39 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                 .map(
                   (e) => _DynamicEditor(
                     comp: e.value,
-                    onNameChanged: (name) => setState(() {
-                      final old = dynamicComponents[e.key];
-                      dynamicComponents[e.key] = DynamicComponentDef(
-                        name: name,
-                        selectionStrategy: old.selectionStrategy,
-                        rules: old.rules,
-                      );
-                    }),
+                    onNameChanged:
+                        (name) => setState(() {
+                          final old = dynamicComponents[e.key];
+                          dynamicComponents[e.key] = DynamicComponentDef(
+                            name: name,
+                            selectionStrategy: old.selectionStrategy,
+                            rules: old.rules,
+                          );
+                        }),
                     onEditRules: () => _openRuleWizard(e.key),
-                    onDelete: () => setState(() {
-                      dynamicComponents.removeAt(e.key);
-                    }),
+                    onDelete:
+                        () => setState(() {
+                          dynamicComponents.removeAt(e.key);
+                        }),
                   ),
                 )
                 .toList(),
             TextButton.icon(
-              onPressed: () => setState(() {
-                dynamicComponents.add(DynamicComponentDef(name: '', rules: []));
-              }),
+              onPressed:
+                  () => setState(() {
+                    dynamicComponents.add(
+                      DynamicComponentDef(name: '', rules: []),
+                    );
+                  }),
               icon: const Icon(Icons.add),
               label: const Text('Add Dynamic Component'),
             ),
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _save,
+        child: const Icon(Icons.save),
       ),
     );
   }
@@ -259,8 +277,11 @@ class _ParameterEditor extends StatefulWidget {
   final ValueChanged<ParameterDef> onChanged;
   final VoidCallback onDelete;
 
-  const _ParameterEditor(
-      {required this.def, required this.onChanged, required this.onDelete});
+  const _ParameterEditor({
+    required this.def,
+    required this.onChanged,
+    required this.onDelete,
+  });
 
   @override
   State<_ParameterEditor> createState() => _ParameterEditorState();
@@ -289,11 +310,12 @@ class _ParameterEditorState extends State<_ParameterEditor> {
         key: key.text.trim(),
         type: type,
         unit: unit.text.trim().isEmpty ? null : unit.text.trim(),
-        allowedValues: allowed.text
-            .split(',')
-            .map((e) => e.trim())
-            .where((e) => e.isNotEmpty)
-            .toList(),
+        allowedValues:
+            allowed.text
+                .split(',')
+                .map((e) => e.trim())
+                .where((e) => e.isNotEmpty)
+                .toList(),
         required: requiredField,
       ),
     );
@@ -327,14 +349,15 @@ class _ParameterEditorState extends State<_ParameterEditor> {
                       _notify();
                     }
                   },
-                  items: ParamType.values
-                      .map(
-                        (e) => DropdownMenuItem(
-                          value: e,
-                          child: Text(paramTypeToString(e)),
-                        ),
-                      )
-                      .toList(),
+                  items:
+                      ParamType.values
+                          .map(
+                            (e) => DropdownMenuItem(
+                              value: e,
+                              child: Text(paramTypeToString(e)),
+                            ),
+                          )
+                          .toList(),
                 ),
                 IconButton(
                   onPressed: widget.onDelete,
@@ -398,8 +421,11 @@ class _StaticEditor extends StatefulWidget {
   final ValueChanged<StaticComponent> onChanged;
   final VoidCallback onDelete;
 
-  const _StaticEditor(
-      {required this.comp, required this.onChanged, required this.onDelete});
+  const _StaticEditor({
+    required this.comp,
+    required this.onChanged,
+    required this.onDelete,
+  });
 
   @override
   State<_StaticEditor> createState() => _StaticEditorState();
@@ -528,5 +554,3 @@ class _DynamicEditorState extends State<_DynamicEditor> {
     super.dispose();
   }
 }
-
-

--- a/test/local_repo_test.dart
+++ b/test/local_repo_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bom_builder/core/models.dart';
+import 'package:bom_builder/data/local_repo.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('local_repo_test');
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+        return tempDir.path;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    channel.setMockMethodCallHandler(null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('saves and reloads a standard', () async {
+    final repo = LocalStandardsRepo();
+    final std = StandardDef(
+      code: 'T1',
+      name: 'Test',
+      parameters: [],
+      staticComponents: [],
+      dynamicComponents: [],
+    );
+    await repo.saveStandard(std);
+    final list = await repo.listStandards();
+    expect(list.length, 1);
+    expect(list.first.code, 'T1');
+  });
+}


### PR DESCRIPTION
## Summary
- add floating save buttons to standard and rule editors for clear user action
- cover local standards repository with persistence test

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e3229a448326a504f8dfbefb67b0