### PR TITLE
feat: improve button contrast and theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,9 +9,26 @@ class BomApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    final colorScheme = ColorScheme.fromSeed(seedColor: Colors.indigo);
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: HomeScreen(),
+      theme: ThemeData(
+        colorScheme: colorScheme,
+        appBarTheme: AppBarTheme(
+          backgroundColor: colorScheme.primary,
+          foregroundColor: Colors.white,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: Colors.white,
+          ),
+        ),
+        textButtonTheme: TextButtonThemeData(
+          style: TextButton.styleFrom(foregroundColor: colorScheme.primary),
+        ),
+      ),
+      home: const HomeScreen(),
     );
   }
 }

--- a/lib/ui/rule_wizard.dart
+++ b/lib/ui/rule_wizard.dart
@@ -449,7 +449,11 @@ class _RuleWizardState extends State<RuleWizard> {
         actions: [
           TextButton(
             onPressed: _save,
-            child: const Text('Save', style: TextStyle(color: Colors.white)),
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Theme.of(context).colorScheme.secondary,
+            ),
+            child: const Text('Save'),
           ),
         ],
       ),

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -152,7 +152,11 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
         actions: [
           TextButton(
             onPressed: _save,
-            child: const Text('Save', style: TextStyle(color: Colors.white)),
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Theme.of(context).colorScheme.secondary,
+            ),
+            child: const Text('Save'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- introduce global color scheme and themed buttons
- give Save buttons contrasting background color

## Testing
- `flutter test` *(failed: command hung after resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e72459a4832686b041ae0ec2c9c7