### PR TITLE
Add BOM CSV exporter and integrate with project screen

### DIFF
--- a/lib/core/bom_exporter.dart
+++ b/lib/core/bom_exporter.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'engine.dart';
+import 'models.dart';
+
+class BomExporter {
+  final RuleEngine engine;
+  BomExporter({RuleEngine? engine}) : engine = engine ?? RuleEngine();
+
+  /// Generates BOM for each location and returns CSV string.
+  String buildCsv(List<WorkLocation> locations, List<StandardDef> standards) {
+    final sb = StringBuffer();
+    sb.writeln('location,standard,mm,qty,source');
+    for (final loc in locations) {
+      for (final code in loc.standards) {
+        final std = standards.firstWhere(
+            (s) => s.code == code,
+            orElse: () => StandardDef(code: code, name: ''));
+        if (std.code != code || std.name.isEmpty && std.staticComponents.isEmpty && std.dynamicComponents.isEmpty) {
+          continue;
+        }
+        final lines = engine.evaluate(std, loc.variables);
+        for (final line in lines) {
+          sb.writeln('${_esc(loc.barcode)},${_esc(std.code)},${_esc(line.mm)},${line.qty},${_esc(line.source)}');
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  /// Writes the CSV to the given file path.
+  Future<void> writeCsv(String path, List<WorkLocation> locations, List<StandardDef> standards) async {
+    final csv = buildCsv(locations, standards);
+    final file = File(path);
+    await file.writeAsString(csv);
+  }
+
+  String _esc(String v) {
+    if (v.contains(',') || v.contains('"') || v.contains('\n')) {
+      final escaped = v.replaceAll('"', '""');
+      return '"$escaped"';
+    }
+    return v;
+  }
+}

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -200,3 +200,15 @@ class CacheEntry {
   final DateTime createdAt;
   CacheEntry({required this.standardId, required this.inputs, required this.bom, required this.status, required this.createdAt});
 }
+
+class WorkLocation {
+  String barcode;
+  Set<String> standards;
+  Map<String, dynamic> variables;
+  WorkLocation({
+    this.barcode = '',
+    Set<String>? standards,
+    Map<String, dynamic>? variables,
+  })  : standards = standards ?? <String>{},
+        variables = variables ?? <String, dynamic>{};
+}

--- a/lib/ui/project_screen.dart
+++ b/lib/ui/project_screen.dart
@@ -1,19 +1,8 @@
 import 'package:flutter/material.dart';
 import '../core/models.dart';
 import '../data/repo_factory.dart';
+import '../core/bom_exporter.dart';
 import 'standards_manager_screen.dart';
-
-class WorkLocation {
-  String barcode;
-  Set<String> standards;
-  Map<String, dynamic> variables;
-  WorkLocation({
-    this.barcode = '',
-    Set<String>? standards,
-    Map<String, dynamic>? variables,
-  })  : standards = standards ?? <String>{},
-        variables = variables ?? <String, dynamic>{};
-}
 
 class ProjectScreen extends StatefulWidget {
   final int initialCount;
@@ -87,7 +76,15 @@ class _ProjectScreenState extends State<ProjectScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Project')),
+      appBar: AppBar(
+        title: const Text('Project'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.download),
+            onPressed: _exportCsv,
+          ),
+        ],
+      ),
       body: ListView.builder(
         itemCount: locations.length,
         itemBuilder: (context, index) {
@@ -116,6 +113,28 @@ class _ProjectScreenState extends State<ProjectScreen> {
       floatingActionButton: FloatingActionButton(
         onPressed: _addLocation,
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _exportCsv() async {
+    final repo = createRepo();
+    final standards = await repo.listStandards();
+    final exporter = BomExporter();
+    final csv = exporter.buildCsv(locations, standards);
+    await showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('BOM CSV'),
+        content: SingleChildScrollView(
+          child: SelectableText(csv),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
       ),
     );
   }

--- a/test/bom_export_test.dart
+++ b/test/bom_export_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bom_builder/core/models.dart';
+import 'package:bom_builder/core/bom_exporter.dart';
+
+void main() {
+  test('buildCsv aggregates location BOM', () {
+    final std1 = StandardDef(
+      code: 'S1',
+      name: 'Std1',
+      staticComponents: [StaticComponent(mm: 'MM1', qty: 1)],
+    );
+    final std2 = StandardDef(
+      code: 'S2',
+      name: 'Std2',
+      dynamicComponents: [
+        DynamicComponentDef(name: 'Conn', rules: [
+          RuleDef(expr: {'==': [1, 1]}, outputs: [OutputSpec(mm: 'MM2', qty: 2)])
+        ])
+      ],
+    );
+
+    final locations = [
+      WorkLocation(barcode: 'L1', standards: {'S1'}),
+      WorkLocation(barcode: 'L2', standards: {'S1', 'S2'}),
+    ];
+
+    final exporter = BomExporter();
+    final csv = exporter.buildCsv(locations, [std1, std2]);
+    final lines = csv.trim().split('\n');
+    expect(lines.first, 'location,standard,mm,qty,source');
+    expect(lines.length, 4);
+    expect(lines.contains('L1,S1,MM1,1,static'), isTrue);
+    expect(lines.contains('L2,S1,MM1,1,static'), isTrue);
+    expect(lines.contains('L2,S2,MM2,2,rule:Conn'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Define `WorkLocation` model and export utility for BOM CSV generation
- Add `BomExporter` to build or write CSV files per location standards
- Wire exporter into project screen with a download button
- Cover CSV generation with unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c31b8262888326af2d82e9f6431cbe