### PR TITLE
Add global parameter management

### DIFF
--- a/lib/data/repo.dart
+++ b/lib/data/repo.dart
@@ -5,8 +5,8 @@ abstract class StandardsRepo {
   Future<void> saveStandard(StandardDef std);
   Future<void> deleteStandard(String code);
 
-  Future<Map<String, String>> loadAliases();
-  Future<void> saveAliases(Map<String, String> aliases);
+  Future<List<ParameterDef>> loadGlobalParameters();
+  Future<void> saveGlobalParameters(List<ParameterDef> parameters);
 
   Future<void> saveCacheEntry(String key, Map<String, dynamic> entryJson);
   Future<Map<String, dynamic>?> getCacheEntry(String key);

--- a/lib/data/web_repo.dart
+++ b/lib/data/web_repo.dart
@@ -4,10 +4,10 @@ import '../core/models.dart';
 import 'repo.dart';
 
 class WebStandardsRepo implements StandardsRepo {
-  static const _kStandards = 'bom_standards';
-  static const _kAliases   = 'bom_aliases';
-  static const _kPending   = 'bom_cache_pending';
-  static const _kApproved  = 'bom_cache_approved';
+  static const _kStandards   = 'bom_standards';
+  static const _kParameters  = 'bom_parameters';
+  static const _kPending     = 'bom_cache_pending';
+  static const _kApproved    = 'bom_cache_approved';
 
   Map<String, dynamic> _getMap(String key) {
     final txt = html.window.localStorage[key];
@@ -32,7 +32,7 @@ class WebStandardsRepo implements StandardsRepo {
     for (final e in m.entries) {
       out.add(StandardDef.fromJson((e.value as Map).cast<String, dynamic>()));
     }
-    out.sort((a,b)=>a.code.compareTo(b.code));
+    out.sort((a, b) => a.code.compareTo(b.code));
     return out;
   }
 
@@ -51,14 +51,28 @@ class WebStandardsRepo implements StandardsRepo {
   }
 
   @override
-  Future<Map<String, String>> loadAliases() async {
-    final m = _getMap(_kAliases);
-    return m.map((k,v)=>MapEntry(k, v.toString()));
+  Future<List<ParameterDef>> loadGlobalParameters() async {
+    final raw = _getMap(_kParameters);
+    final list = <ParameterDef>[];
+    final values = raw['items'];
+    if (values is List) {
+      for (final entry in values) {
+        if (entry is Map) {
+          list.add(ParameterDef.fromJson(entry.cast<String, dynamic>()));
+        }
+      }
+    }
+    return list;
   }
 
   @override
-  Future<void> saveAliases(Map<String, String> aliases) async {
-    _setMap(_kAliases, aliases);
+  Future<void> saveGlobalParameters(List<ParameterDef> parameters) async {
+    _setMap(
+      _kParameters,
+      {
+        'items': parameters.map((e) => e.toJson()).toList(),
+      },
+    );
   }
 
   @override
@@ -80,7 +94,7 @@ class WebStandardsRepo implements StandardsRepo {
   @override
   Future<Map<String, Map<String, dynamic>>> listPendingCache() async {
     final p = _getMap(_kPending);
-    return p.map((k,v)=>MapEntry(k, (v as Map).cast<String, dynamic>()));
+    return p.map((k, v) => MapEntry(k, (v as Map).cast<String, dynamic>()));
   }
 
   @override

--- a/lib/ui/global_parameters_screen.dart
+++ b/lib/ui/global_parameters_screen.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import '../core/models.dart';
+import '../data/repo.dart';
+import '../data/repo_factory.dart';
+import 'widgets/parameter_editor.dart';
+
+class GlobalParametersScreen extends StatefulWidget {
+  const GlobalParametersScreen({super.key});
+
+  @override
+  State<GlobalParametersScreen> createState() => _GlobalParametersScreenState();
+}
+
+class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
+  late final StandardsRepo repo;
+  List<ParameterDef> parameters = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    repo = createRepo();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final list = await repo.loadGlobalParameters();
+      setState(() {
+        parameters = list;
+        _loading = false;
+      });
+    } catch (_) {
+      setState(() {
+        parameters = [];
+        _loading = false;
+      });
+    }
+  }
+
+  void _onParameterChanged(int index, ParameterDef def) {
+    setState(() {
+      parameters[index] = def;
+    });
+  }
+
+  void _removeParameter(int index) {
+    setState(() {
+      parameters.removeAt(index);
+    });
+  }
+
+  void _addParameter() {
+    setState(() {
+      parameters.add(ParameterDef(key: '', type: ParamType.text));
+    });
+  }
+
+  Future<void> _save() async {
+    try {
+      final cleaned = <ParameterDef>[];
+      final seen = <String>{};
+      for (final p in parameters) {
+        final key = p.key.trim();
+        if (key.isEmpty) {
+          continue;
+        }
+        if (!seen.add(key)) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Duplicate parameter key: $key')),
+          );
+          return;
+        }
+        final unit = p.unit?.trim();
+        cleaned.add(
+          ParameterDef(
+            key: key,
+            type: p.type,
+            unit: unit == null || unit.isEmpty ? null : unit,
+            allowedValues: p.allowedValues
+                .map((e) => e.trim())
+                .where((e) => e.isNotEmpty)
+                .toList(),
+            required: p.required,
+          ),
+        );
+      }
+      cleaned.sort((a, b) => a.key.toLowerCase().compareTo(b.key.toLowerCase()));
+      await repo.saveGlobalParameters(cleaned);
+      setState(() {
+        parameters = List<ParameterDef>.from(cleaned);
+      });
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Parameters saved.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Save error: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Global Parameters'),
+        actions: [
+          TextButton(
+            onPressed: _save,
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Theme.of(context).colorScheme.secondary,
+            ),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : parameters.isEmpty
+              ? const Center(child: Text('No parameters defined yet.'))
+              : Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: ListView(
+                    children: [
+                      ...parameters
+                          .asMap()
+                          .entries
+                          .map(
+                            (e) => ParameterEditor(
+                              key: ValueKey('global_param_${e.key}_${parameters[e.key].key}'),
+                              def: e.value,
+                              onChanged: (p) => _onParameterChanged(e.key, p),
+                              onDelete: () => _removeParameter(e.key),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                  ),
+                ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addParameter,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/ui/home_screen.dart
+++ b/lib/ui/home_screen.dart
@@ -4,6 +4,7 @@ import '../data/repo.dart';
 import '../data/repo_factory.dart';
 import 'project_screen.dart';
 import 'standards_manager_screen.dart';
+import 'global_parameters_screen.dart';
 import '../data/project_repo.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -21,16 +22,16 @@ class HomeScreen extends StatelessWidget {
               Tab(text: 'Job'),
               Tab(text: 'Standards'),
               Tab(text: 'Approvals'),
-              Tab(text: 'Aliases'),
+              Tab(text: 'Parameters'),
             ],
           ),
         ),
-        body: const TabBarView(
+        body: TabBarView(
           children: [
-            _JobTab(),
-            StandardsManagerScreen(),
-            Center(child: Text('Approvals')),
-            Center(child: Text('Aliases')),
+            const _JobTab(),
+            const StandardsManagerScreen(),
+            const Center(child: Text('Approvals')),
+            const GlobalParametersScreen(),
           ],
         ),
       ),

--- a/lib/ui/widgets/parameter_editor.dart
+++ b/lib/ui/widgets/parameter_editor.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+
+import '../../core/models.dart';
+
+class ParameterEditor extends StatefulWidget {
+  final ParameterDef def;
+  final ValueChanged<ParameterDef> onChanged;
+  final VoidCallback onDelete;
+
+  const ParameterEditor({
+    super.key,
+    required this.def,
+    required this.onChanged,
+    required this.onDelete,
+  });
+
+  @override
+  State<ParameterEditor> createState() => _ParameterEditorState();
+}
+
+class _ParameterEditorState extends State<ParameterEditor> {
+  late TextEditingController key;
+  late TextEditingController unit;
+  late TextEditingController allowed;
+  late bool requiredField;
+  late ParamType type;
+
+  @override
+  void initState() {
+    super.initState();
+    key = TextEditingController(text: widget.def.key);
+    unit = TextEditingController(text: widget.def.unit ?? '');
+    allowed = TextEditingController(text: widget.def.allowedValues.join(','));
+    requiredField = widget.def.required;
+    type = widget.def.type;
+  }
+
+  @override
+  void didUpdateWidget(covariant ParameterEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.def.key != widget.def.key) {
+      key.text = widget.def.key;
+    }
+    final oldUnit = oldWidget.def.unit ?? '';
+    final newUnit = widget.def.unit ?? '';
+    if (oldUnit != newUnit) {
+      unit.text = newUnit;
+    }
+    if (oldWidget.def.type != widget.def.type) {
+      type = widget.def.type;
+    }
+    if (oldWidget.def.required != widget.def.required) {
+      requiredField = widget.def.required;
+    }
+    if (oldWidget.def.allowedValues.join(',') !=
+        widget.def.allowedValues.join(',')) {
+      allowed.text = widget.def.allowedValues.join(',');
+    }
+  }
+
+  void _notify() {
+    widget.onChanged(
+      ParameterDef(
+        key: key.text.trim(),
+        type: type,
+        unit: unit.text.trim().isEmpty ? null : unit.text.trim(),
+        allowedValues: allowed.text
+            .split(',')
+            .map((e) => e.trim())
+            .where((e) => e.isNotEmpty)
+            .toList(),
+        required: requiredField,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: key,
+                    decoration: const InputDecoration(labelText: 'Key'),
+                    onChanged: (_) => _notify(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                DropdownButton<ParamType>(
+                  value: type,
+                  onChanged: (v) {
+                    if (v != null) {
+                      setState(() {
+                        type = v;
+                      });
+                      _notify();
+                    }
+                  },
+                  items: ParamType.values
+                      .map(
+                        (e) => DropdownMenuItem(
+                          value: e,
+                          child: Text(paramTypeToString(e)),
+                        ),
+                      )
+                      .toList(),
+                ),
+                IconButton(
+                  onPressed: widget.onDelete,
+                  icon: const Icon(Icons.delete),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: unit,
+                    decoration: const InputDecoration(labelText: 'Unit'),
+                    onChanged: (_) => _notify(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: allowed,
+                    decoration: const InputDecoration(
+                      labelText: 'Allowed Values (comma)',
+                    ),
+                    onChanged: (_) => _notify(),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Checkbox(
+                  value: requiredField,
+                  onChanged: (v) {
+                    setState(() {
+                      requiredField = v ?? false;
+                    });
+                    _notify();
+                  },
+                ),
+                const Text('Required'),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    key.dispose();
+    unit.dispose();
+    allowed.dispose();
+    super.dispose();
+  }
+}

--- a/test/global_parameters_screen_test.dart
+++ b/test/global_parameters_screen_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bom_builder/ui/global_parameters_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('global_parameters_test');
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+        return tempDir.path;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    channel.setMockMethodCallHandler(null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('renders Global Parameters screen title', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: GlobalParametersScreen()));
+    await tester.pumpAndSettle();
+    expect(find.text('Global Parameters'), findsOneWidget);
+  });
+}

--- a/test/local_repo_test.dart
+++ b/test/local_repo_test.dart
@@ -40,4 +40,19 @@ void main() {
     expect(list.length, 1);
     expect(list.first.code, 'T1');
   });
+
+  test('saves and reloads global parameters', () async {
+    final repo = LocalStandardsRepo();
+    final params = [
+      ParameterDef(key: 'Height', type: ParamType.number, unit: 'ft'),
+      ParameterDef(key: 'Color', type: ParamType.enumType, allowedValues: ['Red', 'Blue']),
+    ];
+
+    await repo.saveGlobalParameters(params);
+    final loaded = await repo.loadGlobalParameters();
+
+    expect(loaded.length, 2);
+    expect(loaded.first.key, params.first.key);
+    expect(loaded[1].allowedValues, ['Red', 'Blue']);
+  });
 }


### PR DESCRIPTION
## Summary
- introduce global parameter persistence in the standards repositories so parameter definitions can be reused across standards
- enhance the standards manager to load global parameters, allow selecting existing definitions, and ensure saved standards publish their parameters globally
- replace the Aliases tab with a global parameters screen, share the parameter editor widget, and cover the new behaviour with repository and widget tests

## Testing
- `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb01b65f3c8326b4649ecd88f5c4b5