### PR TITLE
Fix parameter editor focus loss in release builds

### DIFF
--- a/lib/ui/global_parameters_screen.dart
+++ b/lib/ui/global_parameters_screen.dart
@@ -15,7 +15,18 @@ class GlobalParametersScreen extends StatefulWidget {
 class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
   late final StandardsRepo repo;
   List<ParameterDef> parameters = [];
+  final List<String> _parameterIds = [];
+  int _nextParameterId = 0;
   bool _loading = true;
+
+  String _createParameterId() => 'global_param_${_nextParameterId++}';
+
+  void _resetParameterIds() {
+    _nextParameterId = 0;
+    _parameterIds
+      ..clear()
+      ..addAll(List.generate(parameters.length, (_) => _createParameterId()));
+  }
 
   @override
   void initState() {
@@ -29,11 +40,13 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
       final list = await repo.loadGlobalParameters();
       setState(() {
         parameters = list;
+        _resetParameterIds();
         _loading = false;
       });
     } catch (_) {
       setState(() {
         parameters = [];
+        _resetParameterIds();
         _loading = false;
       });
     }
@@ -48,12 +61,14 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
   void _removeParameter(int index) {
     setState(() {
       parameters.removeAt(index);
+      _parameterIds.removeAt(index);
     });
   }
 
   void _addParameter() {
     setState(() {
       parameters.add(ParameterDef(key: '', type: ParamType.text));
+      _parameterIds.add(_createParameterId());
     });
   }
 
@@ -90,6 +105,7 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
       await repo.saveGlobalParameters(cleaned);
       setState(() {
         parameters = List<ParameterDef>.from(cleaned);
+        _resetParameterIds();
       });
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -132,7 +148,7 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
                           .entries
                           .map(
                             (e) => ParameterEditor(
-                              key: ValueKey('global_param_${e.key}_${parameters[e.key].key}'),
+                              key: ValueKey(_parameterIds[e.key]),
                               def: e.value,
                               onChanged: (p) => _onParameterChanged(e.key, p),
                               onDelete: () => _removeParameter(e.key),

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -81,10 +81,21 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
   late final TextEditingController code;
   late final TextEditingController name;
   List<ParameterDef> parameters = [];
+  final List<String> _parameterIds = [];
+  int _nextParameterId = 0;
   List<StaticComponent> staticComponents = [];
   List<DynamicComponentDef> dynamicComponents = [];
   List<ParameterDef> globalParameters = [];
   bool _loadingGlobalParameters = true;
+
+  String _createParameterId() => 'standard_param_${_nextParameterId++}';
+
+  void _resetParameterIds() {
+    _nextParameterId = 0;
+    _parameterIds
+      ..clear()
+      ..addAll(List.generate(parameters.length, (_) => _createParameterId()));
+  }
 
   void _combineGlobalAndCurrent() {
     final map = <String, ParameterDef>{};
@@ -124,6 +135,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
   void _addNewParameter() {
     setState(() {
       parameters.add(ParameterDef(key: '', type: ParamType.text));
+      _parameterIds.add(_createParameterId());
       _combineGlobalAndCurrent();
     });
   }
@@ -159,6 +171,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
     if (selected == null) return;
     setState(() {
       parameters.add(_cloneParameter(selected));
+      _parameterIds.add(_createParameterId());
       _combineGlobalAndCurrent();
     });
   }
@@ -181,6 +194,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
   void _removeParameterAt(int index) {
     setState(() {
       parameters.removeAt(index);
+      _parameterIds.removeAt(index);
       _combineGlobalAndCurrent();
     });
   }
@@ -216,6 +230,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
     code = TextEditingController(text: e?.code ?? '');
     name = TextEditingController(text: e?.name ?? '');
     parameters = e?.parameters.toList() ?? [];
+    _resetParameterIds();
     staticComponents = e?.staticComponents.toList() ?? [];
     dynamicComponents = e?.dynamicComponents.toList() ?? [];
     _loadGlobalParameters();
@@ -329,7 +344,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                 .entries
                 .map(
                   (e) => ParameterEditor(
-                    key: ValueKey('param_${e.key}_${parameters[e.key].key}'),
+                    key: ValueKey(_parameterIds[e.key]),
                     def: e.value,
                     onChanged: (p) => _onParameterChanged(e.key, p),
                     onDelete: () => _removeParameterAt(e.key),


### PR DESCRIPTION
## Summary
- track stable identifiers for parameter editor rows so the field widgets are not recreated while typing
- update both the global and standard parameter screens to use the persistent ids when building the editor list

## Testing
- not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb15262ad88326a8feaee0f336babb