### PR TITLE
Add confirmations and protect unsaved edits

### DIFF
--- a/lib/ui/dialogs.dart
+++ b/lib/ui/dialogs.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+Future<bool> showConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool isDestructive = false,
+}) async {
+  final theme = Theme.of(context);
+  final confirmStyle = isDestructive
+      ? FilledButton.styleFrom(
+          backgroundColor: theme.colorScheme.error,
+          foregroundColor: theme.colorScheme.onError,
+        )
+      : null;
+
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(cancelLabel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: confirmStyle,
+          child: Text(confirmLabel),
+        ),
+      ],
+    ),
+  );
+
+  return result ?? false;
+}
+
+Future<bool> showTextConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required String hintText,
+  required String expectedText,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool isDestructive = false,
+}) async {
+  final controller = TextEditingController();
+  try {
+    return (await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) {
+            return StatefulBuilder(
+              builder: (context, setState) {
+                final matches =
+                    controller.text.trim() == expectedText.trim();
+                final theme = Theme.of(context);
+                final confirmStyle = isDestructive
+                    ? FilledButton.styleFrom(
+                        backgroundColor: theme.colorScheme.error,
+                        foregroundColor: theme.colorScheme.onError,
+                      )
+                    : null;
+                return AlertDialog(
+                  title: Text(title),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(message),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: controller,
+                        autofocus: true,
+                        decoration: InputDecoration(hintText: hintText),
+                        onChanged: (_) => setState(() {}),
+                      ),
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: Text(cancelLabel),
+                    ),
+                    FilledButton(
+                      onPressed:
+                          matches ? () => Navigator.of(context).pop(true) : null,
+                      style: confirmStyle,
+                      child: Text(confirmLabel),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        )) ??
+        false;
+  } finally {
+    controller.dispose();
+  }
+}
+

--- a/lib/ui/dynamic_component_rules_screen.dart
+++ b/lib/ui/dynamic_component_rules_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../core/models.dart';
 import 'rule_wizard.dart';
+import 'dialogs.dart';
 
 class DynamicComponentRulesScreen extends StatefulWidget {
   final DynamicComponentDef component;
@@ -61,7 +62,16 @@ class _DynamicComponentRulesScreenState
     }
   }
 
-  void _deleteRule(int index) {
+  Future<void> _deleteRule(int index) async {
+    final confirm = await showConfirmationDialog(
+      context,
+      title: 'Remove rule?',
+      message: 'This rule will be deleted from the dynamic component.',
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    );
+    if (!confirm) return;
+
     setState(() {
       _rules.removeAt(index);
     });
@@ -174,7 +184,9 @@ class _DynamicComponentRulesScreenState
                                     child: const Text('Edit'),
                                   ),
                                   TextButton(
-                                    onPressed: () => _deleteRule(entry.key),
+                                    onPressed: () {
+                                      _deleteRule(entry.key);
+                                    },
                                     child: const Text('Delete'),
                                   ),
                                 ],


### PR DESCRIPTION
## Summary
- add reusable dialog helpers and double-confirm the removal of standards
- prompt before navigating away from editors with unsaved work across standards, locations, and global resources
- require confirmation before destructive actions such as removing parameters, components, rules, and outputs

## Testing
- flutter test *(fails: flutter not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf3496a5c83269cd7a08203b4623f