### PR TITLE
Add confirmations and protect unsaved edits

### DIFF
--- a/lib/ui/dialogs.dart
+++ b/lib/ui/dialogs.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+Future<bool> showConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool isDestructive = false,
+}) async {
+  final theme = Theme.of(context);
+  final confirmStyle = isDestructive
+      ? FilledButton.styleFrom(
+          backgroundColor: theme.colorScheme.error,
+          foregroundColor: theme.colorScheme.onError,
+        )
+      : null;
+
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(cancelLabel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: confirmStyle,
+          child: Text(confirmLabel),
+        ),
+      ],
+    ),
+  );
+
+  return result ?? false;
+}
+
+Future<bool> showTextConfirmationDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required String hintText,
+  required String expectedText,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool isDestructive = false,
+}) async {
+  final controller = TextEditingController();
+  try {
+    return (await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) {
+            return StatefulBuilder(
+              builder: (context, setState) {
+                final matches =
+                    controller.text.trim() == expectedText.trim();
+                final theme = Theme.of(context);
+                final confirmStyle = isDestructive
+                    ? FilledButton.styleFrom(
+                        backgroundColor: theme.colorScheme.error,
+                        foregroundColor: theme.colorScheme.onError,
+                      )
+                    : null;
+                return AlertDialog(
+                  title: Text(title),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(message),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: controller,
+                        autofocus: true,
+                        decoration: InputDecoration(hintText: hintText),
+                        onChanged: (_) => setState(() {}),
+                      ),
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: Text(cancelLabel),
+                    ),
+                    FilledButton(
+                      onPressed:
+                          matches ? () => Navigator.of(context).pop(true) : null,
+                      style: confirmStyle,
+                      child: Text(confirmLabel),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        )) ??
+        false;
+  } finally {
+    controller.dispose();
+  }
+}
+

--- a/lib/ui/dynamic_component_rules_screen.dart
+++ b/lib/ui/dynamic_component_rules_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../core/models.dart';
 import 'rule_wizard.dart';
+import 'dialogs.dart';
 
 class DynamicComponentRulesScreen extends StatefulWidget {
   final DynamicComponentDef component;
@@ -61,7 +62,16 @@ class _DynamicComponentRulesScreenState
     }
   }
 
-  void _deleteRule(int index) {
+  Future<void> _deleteRule(int index) async {
+    final confirm = await showConfirmationDialog(
+      context,
+      title: 'Remove rule?',
+      message: 'This rule will be deleted from the dynamic component.',
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    );
+    if (!confirm) return;
+
     setState(() {
       _rules.removeAt(index);
     });
@@ -174,7 +184,9 @@ class _DynamicComponentRulesScreenState
                                     child: const Text('Edit'),
                                   ),
                                   TextButton(
-                                    onPressed: () => _deleteRule(entry.key),
+                                    onPressed: () {
+                                      _deleteRule(entry.key);
+                                    },
                                     child: const Text('Delete'),
                                   ),
                                 ],

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -6,6 +6,7 @@ import '../core/models.dart';
 import '../data/repo.dart';
 import '../data/repo_factory.dart';
 import 'dynamic_component_rules_screen.dart';
+import 'dialogs.dart';
 import 'widgets/dynamic_component_editor.dart';
 import 'widgets/parameter_editor.dart';
 
@@ -44,6 +45,44 @@ class _StandardsManagerScreenState extends State<StandardsManagerScreen> {
     );
     if (changed == true) {
       _refresh();
+    }
+  }
+
+  Future<void> _deleteStandard(StandardDef std) async {
+    final firstConfirm = await showConfirmationDialog(
+      context,
+      title: 'Delete standard?',
+      message:
+          'This will permanently remove ${std.code} — ${std.name}. This action cannot be undone.',
+      confirmLabel: 'Delete',
+      isDestructive: true,
+    );
+    if (!firstConfirm) return;
+
+    final secondConfirm = await showTextConfirmationDialog(
+      context,
+      title: 'Confirm deletion',
+      message:
+          'Type the standard code to confirm. Deleting a standard cannot be undone.',
+      hintText: std.code,
+      expectedText: std.code,
+      confirmLabel: 'Delete',
+      isDestructive: true,
+    );
+    if (!secondConfirm) return;
+
+    try {
+      await repo.deleteStandard(std.code);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Deleted standard ${std.code}.')),
+      );
+      await _refresh();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Delete error: $e')),
+      );
     }
   }
 
@@ -87,9 +126,20 @@ class _StandardsManagerScreenState extends State<StandardsManagerScreen> {
                       final s = filteredStandards[i];
                       return ListTile(
                         title: Text('${s.code} — ${s.name}'),
-                        trailing: IconButton(
-                          icon: const Icon(Icons.edit),
-                          onPressed: () => _openDetail(s),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.edit),
+                              tooltip: 'Edit standard',
+                              onPressed: () => _openDetail(s),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete_outline),
+                              tooltip: 'Delete standard',
+                              onPressed: () => _deleteStandard(s),
+                            ),
+                          ],
                         ),
                       );
                     },
@@ -128,6 +178,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
   bool _loadingGlobalParameters = true;
   List<DynamicComponentDef> globalDynamicComponents = [];
   bool _loadingGlobalDynamicComponents = true;
+  bool _dirty = false;
 
   String _createParameterId() => 'standard_param_${_nextParameterId++}';
 
@@ -182,6 +233,26 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
   }
 
+  void _markDirty() {
+    if (!_dirty) {
+      setState(() {
+        _dirty = true;
+      });
+    }
+  }
+
+  Future<bool> _confirmDiscardChanges() async {
+    if (!_dirty) return true;
+    return await showConfirmationDialog(
+      context,
+      title: 'Discard changes?',
+      message:
+          'You have unsaved changes for this standard. Leave without saving?',
+      confirmLabel: 'Discard',
+      isDestructive: true,
+    );
+  }
+
   Future<void> _loadGlobalParameters() async {
     try {
       final list = await widget.repo.loadGlobalParameters();
@@ -225,6 +296,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       parameters.add(ParameterDef(key: '', type: ParamType.text));
       _parameterIds.add(_createParameterId());
       _combineGlobalAndCurrent();
+      _dirty = true;
     });
   }
 
@@ -247,6 +319,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       parameters.add(_cloneParameter(selected));
       _parameterIds.add(_createParameterId());
       _combineGlobalAndCurrent();
+      _dirty = true;
     });
   }
 
@@ -271,6 +344,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       dynamicComponents.add(_cloneDynamicComponent(selected));
       _dynamicComponentIds.add(_createDynamicComponentId());
       _combineGlobalDynamicComponents();
+      _dirty = true;
     });
   }
 
@@ -443,14 +517,59 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
     setState(() {
       parameters[index] = def;
       _combineGlobalAndCurrent();
+      _dirty = true;
     });
   }
 
-  void _removeParameterAt(int index) {
+  Future<void> _removeParameterAt(int index) async {
+    final confirm = await showConfirmationDialog(
+      context,
+      title: 'Remove parameter?',
+      message: 'This parameter will be removed from the standard.',
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    );
+    if (!confirm) return;
+
     setState(() {
       parameters.removeAt(index);
       _parameterIds.removeAt(index);
       _combineGlobalAndCurrent();
+      _dirty = true;
+    });
+  }
+
+  Future<void> _removeStaticComponent(int index) async {
+    final confirm = await showConfirmationDialog(
+      context,
+      title: 'Remove static component?',
+      message: 'This component will be removed from the standard.',
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    );
+    if (!confirm) return;
+
+    setState(() {
+      staticComponents.removeAt(index);
+      _dirty = true;
+    });
+  }
+
+  Future<void> _removeDynamicComponent(int index) async {
+    final confirm = await showConfirmationDialog(
+      context,
+      title: 'Remove dynamic component?',
+      message: 'This component will be removed from the standard.',
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    );
+    if (!confirm) return;
+
+    setState(() {
+      dynamicComponents.removeAt(index);
+      _dynamicComponentIds.removeAt(index);
+      _combineGlobalDynamicComponents();
+      _dirty = true;
     });
   }
 
@@ -468,6 +587,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
       setState(() {
         if (updated != null) {
           dynamicComponents[index] = updated;
+          _dirty = true;
         }
         _combineGlobalAndCurrent();
         _combineGlobalDynamicComponents();
@@ -485,6 +605,8 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
     final e = widget.existing;
     code = TextEditingController(text: e?.code ?? '');
     name = TextEditingController(text: e?.name ?? '');
+    code.addListener(_markDirty);
+    name.addListener(_markDirty);
     parameters = e?.parameters.toList() ?? [];
     _resetParameterIds();
     staticComponents = e?.staticComponents.toList() ?? [];
@@ -497,6 +619,8 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
 
   @override
   void dispose() {
+    code.removeListener(_markDirty);
+    name.removeListener(_markDirty);
     code.dispose();
     name.dispose();
     super.dispose();
@@ -606,158 +730,157 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.existing == null ? 'Add Standard' : 'Edit Standard'),
-        actions: [
-          TextButton(
-            onPressed: _save,
-            style: TextButton.styleFrom(
-              foregroundColor: Colors.white,
-              backgroundColor: Theme.of(context).colorScheme.secondary,
-            ),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(12),
-        child: ListView(
-          children: [
-            TextField(
-              controller: code,
-              decoration: const InputDecoration(labelText: 'Code'),
-            ),
-            const SizedBox(height: 8),
-            TextField(
-              controller: name,
-              decoration: const InputDecoration(labelText: 'Name'),
-            ),
-            const SizedBox(height: 8),
-            const Text('Parameters'),
-            const SizedBox(height: 4),
-            if (_loadingGlobalParameters)
-              const LinearProgressIndicator(),
-            if (_loadingGlobalParameters)
-              const SizedBox(height: 8),
-            ...parameters
-                .asMap()
-                .entries
-                .map(
-                  (e) => ParameterEditor(
-                    key: ValueKey(_parameterIds[e.key]),
-                    def: e.value,
-                    onChanged: (p) => _onParameterChanged(e.key, p),
-                    onDelete: () => _removeParameterAt(e.key),
-                  ),
-                )
-                .toList(),
-            Wrap(
-              spacing: 8,
-              children: [
-                TextButton.icon(
-                  onPressed: _addNewParameter,
-                  icon: const Icon(Icons.add),
-                  label: const Text('New Parameter'),
-                ),
-                TextButton.icon(
-                  onPressed:
-                      _loadingGlobalParameters ? null : _addExistingParameter,
-                  icon: const Icon(Icons.playlist_add),
-                  label: const Text('Add Existing Parameter'),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            const Text('Static Components'),
-            const SizedBox(height: 4),
-            ...staticComponents
-                .asMap()
-                .entries
-                .map(
-                  (e) => _StaticEditor(
-                    comp: e.value,
-                    onChanged:
-                        (c) => setState(() {
-                          staticComponents[e.key] = c;
-                        }),
-                    onDelete:
-                        () => setState(() {
-                          staticComponents.removeAt(e.key);
-                        }),
-                  ),
-                )
-                .toList(),
-            TextButton.icon(
-              onPressed:
-                  () => setState(() {
-                    staticComponents.add(StaticComponent(mm: '', qty: 1));
-                  }),
-              icon: const Icon(Icons.add),
-              label: const Text('Add Static Component'),
-            ),
-            const SizedBox(height: 8),
-            const Text('Dynamic Components'),
-            const SizedBox(height: 4),
-            if (_loadingGlobalDynamicComponents)
-              const LinearProgressIndicator(),
-            if (_loadingGlobalDynamicComponents)
-              const SizedBox(height: 8),
-            ...dynamicComponents
-                .asMap()
-                .entries
-                .map(
-                  (e) => DynamicComponentEditor(
-                    key: ValueKey(_dynamicComponentIds[e.key]),
-                    comp: e.value,
-                    onNameChanged: (name) => setState(() {
-                      final old = dynamicComponents[e.key];
-                      dynamicComponents[e.key] = DynamicComponentDef(
-                        name: name,
-                        selectionStrategy: old.selectionStrategy,
-                        rules: old.rules,
-                      );
-                      _combineGlobalDynamicComponents();
-                    }),
-                    onEditRules: () => _openRulesManager(e.key),
-                    onDelete:
-                        () => setState(() {
-                          dynamicComponents.removeAt(e.key);
-                          _dynamicComponentIds.removeAt(e.key);
-                          _combineGlobalDynamicComponents();
-                        }),
-                  ),
-                )
-                .toList(),
-            Wrap(
-              spacing: 8,
-              children: [
-                TextButton.icon(
-                  onPressed: () => setState(() {
-                    dynamicComponents.add(
-                      DynamicComponentDef(name: '', rules: []),
-                    );
-                    _dynamicComponentIds.add(_createDynamicComponentId());
-                    _combineGlobalDynamicComponents();
-                  }),
-                  icon: const Icon(Icons.add),
-                  label: const Text('New Dynamic Component'),
-                ),
-                TextButton.icon(
-                  onPressed: _loadingGlobalDynamicComponents
-                      ? null
-                      : _addExistingDynamicComponent,
-                  icon: const Icon(Icons.playlist_add),
-                  label: const Text('Add Existing Dynamic Component'),
-                ),
-              ],
+    return WillPopScope(
+      onWillPop: _confirmDiscardChanges,
+      child: Scaffold(
+        appBar: AppBar(
+          title:
+              Text(widget.existing == null ? 'Add Standard' : 'Edit Standard'),
+          actions: [
+            TextButton(
+              onPressed: _save,
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.white,
+                backgroundColor: Theme.of(context).colorScheme.secondary,
+              ),
+              child: const Text('Save'),
             ),
           ],
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _save,
-        child: const Icon(Icons.save),
+        body: Padding(
+          padding: const EdgeInsets.all(12),
+          child: ListView(
+            children: [
+              TextField(
+                controller: code,
+                decoration: const InputDecoration(labelText: 'Code'),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: name,
+                decoration: const InputDecoration(labelText: 'Name'),
+              ),
+              const SizedBox(height: 8),
+              const Text('Parameters'),
+              const SizedBox(height: 4),
+              if (_loadingGlobalParameters)
+                const LinearProgressIndicator(),
+              if (_loadingGlobalParameters)
+                const SizedBox(height: 8),
+              ...parameters
+                  .asMap()
+                  .entries
+                  .map(
+                    (e) => ParameterEditor(
+                      key: ValueKey(_parameterIds[e.key]),
+                      def: e.value,
+                      onChanged: (p) => _onParameterChanged(e.key, p),
+                      onDelete: () => _removeParameterAt(e.key),
+                    ),
+                  )
+                  .toList(),
+              Wrap(
+                spacing: 8,
+                children: [
+                  TextButton.icon(
+                    onPressed: _addNewParameter,
+                    icon: const Icon(Icons.add),
+                    label: const Text('New Parameter'),
+                  ),
+                  TextButton.icon(
+                    onPressed:
+                        _loadingGlobalParameters ? null : _addExistingParameter,
+                    icon: const Icon(Icons.playlist_add),
+                    label: const Text('Add Existing Parameter'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              const Text('Static Components'),
+              const SizedBox(height: 4),
+              ...staticComponents
+                  .asMap()
+                  .entries
+                  .map(
+                    (e) => _StaticEditor(
+                      comp: e.value,
+                      onChanged:
+                          (c) => setState(() {
+                            staticComponents[e.key] = c;
+                            _dirty = true;
+                          }),
+                      onDelete: () => _removeStaticComponent(e.key),
+                    ),
+                  )
+                  .toList(),
+              TextButton.icon(
+                onPressed: () => setState(() {
+                  staticComponents.add(StaticComponent(mm: '', qty: 1));
+                  _dirty = true;
+                }),
+                icon: const Icon(Icons.add),
+                label: const Text('Add Static Component'),
+              ),
+              const SizedBox(height: 8),
+              const Text('Dynamic Components'),
+              const SizedBox(height: 4),
+              if (_loadingGlobalDynamicComponents)
+                const LinearProgressIndicator(),
+              if (_loadingGlobalDynamicComponents)
+                const SizedBox(height: 8),
+              ...dynamicComponents
+                  .asMap()
+                  .entries
+                  .map(
+                    (e) => DynamicComponentEditor(
+                      key: ValueKey(_dynamicComponentIds[e.key]),
+                      comp: e.value,
+                      onNameChanged: (name) => setState(() {
+                        final old = dynamicComponents[e.key];
+                        dynamicComponents[e.key] = DynamicComponentDef(
+                          name: name,
+                          selectionStrategy: old.selectionStrategy,
+                          rules: old.rules,
+                        );
+                        _combineGlobalDynamicComponents();
+                        _dirty = true;
+                      }),
+                      onEditRules: () => _openRulesManager(e.key),
+                      onDelete: () => _removeDynamicComponent(e.key),
+                    ),
+                  )
+                  .toList(),
+              Wrap(
+                spacing: 8,
+                children: [
+                  TextButton.icon(
+                    onPressed: () => setState(() {
+                      dynamicComponents.add(
+                        DynamicComponentDef(name: '', rules: []),
+                      );
+                      _dynamicComponentIds.add(_createDynamicComponentId());
+                      _combineGlobalDynamicComponents();
+                      _dirty = true;
+                    }),
+                    icon: const Icon(Icons.add),
+                    label: const Text('New Dynamic Component'),
+                  ),
+                  TextButton.icon(
+                    onPressed: _loadingGlobalDynamicComponents
+                        ? null
+                        : _addExistingDynamicComponent,
+                    icon: const Icon(Icons.playlist_add),
+                    label: const Text('Add Existing Dynamic Component'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _save,
+          child: const Icon(Icons.save),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add reusable dialog helpers and double-confirm the removal of standards
- prompt before navigating away from editors with unsaved work across standards, locations, and global resources
- require confirmation before destructive actions such as removing parameters, components, rules, and outputs
- fix the standards detail screen scaffold so its save action builds correctly

## Testing
- flutter test *(fails: flutter not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf3496a5c83269cd7a08203b4623f