### PR TITLE
Add configurable standards repository root

### DIFF
--- a/lib/data/repo_factory.dart
+++ b/lib/data/repo_factory.dart
@@ -3,4 +3,4 @@ import 'repo.dart';
 import 'repo_factory_io.dart'
     if (dart.library.html) 'repo_factory_web.dart' as impl;
 
-StandardsRepo createRepo() => impl.getRepo();
+Future<StandardsRepo> createRepo() => impl.getRepo();

--- a/lib/data/repo_factory_io.dart
+++ b/lib/data/repo_factory_io.dart
@@ -1,5 +1,13 @@
 // lib/data/repo_factory_io.dart
 import 'repo.dart';
 import 'local_repo.dart';
+import 'repo_location_store.dart';
 
-StandardsRepo getRepo() => LocalStandardsRepo();
+Future<StandardsRepo> getRepo() async {
+  final store = RepoLocationStore.instance;
+  final override = await store.loadPreferredRoot();
+  return LocalStandardsRepo(
+    overrideRootPath: override,
+    locationStore: store,
+  );
+}

--- a/lib/data/repo_factory_web.dart
+++ b/lib/data/repo_factory_web.dart
@@ -2,4 +2,4 @@
 import 'repo.dart';
 import 'web_repo.dart';
 
-StandardsRepo getRepo() => WebStandardsRepo();
+Future<StandardsRepo> getRepo() async => WebStandardsRepo();

--- a/lib/data/repo_location_store.dart
+++ b/lib/data/repo_location_store.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+typedef _DocumentsDirectoryProvider = Future<Directory> Function();
+
+class RepoLocationStore {
+  RepoLocationStore._({
+    _DocumentsDirectoryProvider? documentsDirectoryProvider,
+  }) : _documentsDirectoryProvider =
+            documentsDirectoryProvider ?? getApplicationDocumentsDirectory;
+
+  factory RepoLocationStore({
+    _DocumentsDirectoryProvider? documentsDirectoryProvider,
+  }) =
+      RepoLocationStore._;
+
+  static final RepoLocationStore instance = RepoLocationStore._();
+
+  final _DocumentsDirectoryProvider _documentsDirectoryProvider;
+  final StreamController<String?> _controller =
+      StreamController<String?>.broadcast();
+  String? _cachedPath;
+  bool _loaded = false;
+
+  Stream<String?> get changes => _controller.stream;
+
+  Future<File> _configFile() async {
+    final dir = await _documentsDirectoryProvider();
+    final configDir = Directory('${dir.path}/bom_prefs');
+    if (!await configDir.exists()) {
+      await configDir.create(recursive: true);
+    }
+    return File('${configDir.path}/repo_location.json');
+  }
+
+  Future<String?> loadPreferredRoot() async {
+    if (_loaded) return _cachedPath;
+    final file = await _configFile();
+    if (await file.exists()) {
+      try {
+        final text = await file.readAsString();
+        if (text.trim().isNotEmpty) {
+          final data = jsonDecode(text);
+          if (data is Map && data['path'] is String) {
+            _cachedPath = data['path'] as String;
+          }
+        }
+      } catch (_) {
+        _cachedPath = null;
+      }
+    }
+    _loaded = true;
+    return _cachedPath;
+  }
+
+  Future<void> setPreferredRoot(String? path) async {
+    final file = await _configFile();
+    if (path == null || path.trim().isEmpty) {
+      if (await file.exists()) {
+        await file.delete();
+      }
+      _cachedPath = null;
+    } else {
+      final normalized = path.trim();
+      await file.writeAsString(jsonEncode({'path': normalized}), flush: true);
+      _cachedPath = normalized;
+    }
+    _loaded = true;
+    _controller.add(_cachedPath);
+  }
+
+  Future<String> resolveRootPath() async {
+    final stored = await loadPreferredRoot();
+    if (stored != null && stored.trim().isNotEmpty) {
+      return stored;
+    }
+    final dir = await _documentsDirectoryProvider();
+    return '${dir.path}/bom_data';
+  }
+}

--- a/lib/ui/project_screen.dart
+++ b/lib/ui/project_screen.dart
@@ -69,7 +69,7 @@ class _ProjectScreenState extends State<ProjectScreen> {
   }
 
   Future<void> _openStandards(int index) async {
-    final repo = createRepo();
+    final repo = await createRepo();
     final allStds = await repo.listStandards();
     final result = await Navigator.of(context).push<Map<String, dynamic>>(
       MaterialPageRoute(
@@ -236,7 +236,7 @@ class _ProjectScreenState extends State<ProjectScreen> {
   }
 
   Future<void> _exportCsv() async {
-    final repo = createRepo();
+    final repo = await createRepo();
     final standards = await repo.listStandards();
     final exporter = BomExporter();
     final csv = exporter.buildCsv(locations, standards);
@@ -407,7 +407,7 @@ class _LocationStandardsScreenState extends State<LocationStandardsScreen> {
     await Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const StandardsManagerScreen()),
     );
-    final repo = createRepo();
+    final repo = await createRepo();
     final list = await repo.listStandards();
     setState(() => available = list);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   path_provider: ^2.1.4
   file_selector: ^1.0.4
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a RepoLocationStore helper to persist the preferred standards root and wire it into LocalStandardsRepo
- make repository factories asynchronous, awaiting any stored override before constructing LocalStandardsRepo
- add a home screen control for selecting/migrating the shared folder and update UI screens to wait for repository initialization

## Testing
- Not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce088ce9d88326816acbaffb523601