### PR TITLE
Add flagged materials persistence to repositories

### DIFF
--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -94,6 +94,40 @@ class StaticComponent {
   Map<String, dynamic> toJson() => {'mm': mm, 'qty': qty};
 }
 
+class FlaggedMaterial {
+  final String mm;
+  final String reason;
+  final String? note;
+  final DateTime? flaggedAt;
+  final String? flaggedBy;
+
+  FlaggedMaterial({
+    required this.mm,
+    required this.reason,
+    this.note,
+    this.flaggedAt,
+    this.flaggedBy,
+  });
+
+  factory FlaggedMaterial.fromJson(Map<String, dynamic> j) => FlaggedMaterial(
+        mm: j['mm'] as String,
+        reason: j['reason'] as String? ?? '',
+        note: j['note'] as String?,
+        flaggedAt: j['flagged_at'] != null
+            ? DateTime.tryParse(j['flagged_at'] as String)
+            : null,
+        flaggedBy: j['flagged_by'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'mm': mm,
+        'reason': reason,
+        if (note != null) 'note': note,
+        if (flaggedAt != null) 'flagged_at': flaggedAt!.toIso8601String(),
+        if (flaggedBy != null) 'flagged_by': flaggedBy,
+      };
+}
+
 class OutputSpec {
   final String mm;
   final int? qty;

--- a/lib/data/local_repo.dart
+++ b/lib/data/local_repo.dart
@@ -53,6 +53,13 @@ class LocalStandardsRepo implements StandardsRepo {
     if (!await dynamicComponentsFile.exists()) {
       await dynamicComponentsFile.writeAsString(jsonEncode(<dynamic>[]), flush: true);
     }
+    final flaggedMaterialsFile = File('${root.path}/flagged_materials.json');
+    if (!await flaggedMaterialsFile.exists()) {
+      await flaggedMaterialsFile.writeAsString(
+        jsonEncode(<dynamic>[]),
+        flush: true,
+      );
+    }
   }
 
   Future<Directory> _ensureRoot() async {
@@ -80,6 +87,11 @@ class LocalStandardsRepo implements StandardsRepo {
   Future<File> _dynamicComponentsFile() async {
     final r = await _ensureRoot();
     return File('${r.path}/dynamic_components.json');
+  }
+
+  Future<File> _flaggedMaterialsFile() async {
+    final r = await _ensureRoot();
+    return File('${r.path}/flagged_materials.json');
   }
 
   Future<File> _pendingFile(String key) async {
@@ -174,6 +186,32 @@ class LocalStandardsRepo implements StandardsRepo {
     final tmp = File('${f.path}.tmp');
     await tmp.writeAsString(
       jsonEncode(components.map((e) => e.toJson()).toList()),
+      flush: true,
+    );
+    await tmp.rename(f.path);
+  }
+
+  @override
+  Future<List<FlaggedMaterial>> loadFlaggedMaterials() async {
+    final f = await _flaggedMaterialsFile();
+    final txt = await f.readAsString();
+    if (txt.trim().isEmpty) return [];
+    final j = jsonDecode(txt);
+    if (j is List) {
+      return j
+          .whereType<Map>()
+          .map((e) => FlaggedMaterial.fromJson((e as Map).cast<String, dynamic>()))
+          .toList();
+    }
+    return [];
+  }
+
+  @override
+  Future<void> saveFlaggedMaterials(List<FlaggedMaterial> materials) async {
+    final f = await _flaggedMaterialsFile();
+    final tmp = File('${f.path}.tmp');
+    await tmp.writeAsString(
+      jsonEncode(materials.map((e) => e.toJson()).toList()),
       flush: true,
     );
     await tmp.rename(f.path);

--- a/lib/data/repo.dart
+++ b/lib/data/repo.dart
@@ -11,6 +11,9 @@ abstract class StandardsRepo {
   Future<List<DynamicComponentDef>> loadGlobalDynamicComponents();
   Future<void> saveGlobalDynamicComponents(List<DynamicComponentDef> components);
 
+  Future<List<FlaggedMaterial>> loadFlaggedMaterials();
+  Future<void> saveFlaggedMaterials(List<FlaggedMaterial> materials);
+
   Future<void> saveCacheEntry(String key, Map<String, dynamic> entryJson);
   Future<Map<String, dynamic>?> getCacheEntry(String key);
   Future<Map<String, Map<String, dynamic>>> listPendingCache();

--- a/lib/data/web_repo.dart
+++ b/lib/data/web_repo.dart
@@ -7,6 +7,7 @@ class WebStandardsRepo implements StandardsRepo {
   static const _kStandards = 'bom_standards';
   static const _kParameters = 'bom_parameters';
   static const _kDynamicComponents = 'bom_dynamic_components';
+  static const _kFlaggedMaterials = 'bom_flagged_materials';
   static const _kPending = 'bom_cache_pending';
   static const _kApproved = 'bom_cache_approved';
 
@@ -100,6 +101,33 @@ class WebStandardsRepo implements StandardsRepo {
       _kDynamicComponents,
       {
         'items': components.map((e) => e.toJson()).toList(),
+      },
+    );
+  }
+
+  @override
+  Future<List<FlaggedMaterial>> loadFlaggedMaterials() async {
+    final raw = _getMap(_kFlaggedMaterials);
+    final list = <FlaggedMaterial>[];
+    final values = raw['items'];
+    if (values is List) {
+      for (final entry in values) {
+        if (entry is Map) {
+          list.add(
+            FlaggedMaterial.fromJson(entry.cast<String, dynamic>()),
+          );
+        }
+      }
+    }
+    return list;
+  }
+
+  @override
+  Future<void> saveFlaggedMaterials(List<FlaggedMaterial> materials) async {
+    _setMap(
+      _kFlaggedMaterials,
+      {
+        'items': materials.map((e) => e.toJson()).toList(),
       },
     );
   }


### PR DESCRIPTION
## Summary
- add a `FlaggedMaterial` domain model with JSON serialization helpers
- extend `StandardsRepo` with flagged material persistence APIs and implement them for local and web storage
- bootstrap a flagged materials file alongside existing local data to keep storage consistent

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d171efca7083268db4247d70b7c416