### PR TITLE
Add flagged materials section to BOM CSV

### DIFF
--- a/lib/core/bom_exporter.dart
+++ b/lib/core/bom_exporter.dart
@@ -8,9 +8,20 @@ class BomExporter {
   BomExporter({RuleEngine? engine}) : engine = engine ?? RuleEngine();
 
   /// Generates BOM for each location and returns CSV string.
-  String buildCsv(List<WorkLocation> locations, List<StandardDef> standards) {
+  String buildCsv(
+    List<WorkLocation> locations,
+    List<StandardDef> standards, {
+    List<FlaggedMaterial> flaggedMaterials = const [],
+  }) {
     final sb = StringBuffer();
     sb.writeln('location,standard,mm,qty,source');
+    final flaggedLookup = <String, FlaggedMaterial>{};
+    for (final flagged in flaggedMaterials) {
+      final key = flagged.mm.trim().toLowerCase();
+      if (key.isEmpty) continue;
+      flaggedLookup[key] = flagged;
+    }
+    final matchedFlagged = <String, FlaggedMaterial>{};
     for (final loc in locations) {
       for (final code in loc.standards) {
         final std = standards.firstWhere(
@@ -22,15 +33,47 @@ class BomExporter {
         final lines = engine.evaluate(std, loc.variables);
         for (final line in lines) {
           sb.writeln('${_esc(loc.barcode)},${_esc(std.code)},${_esc(line.mm)},${line.qty},${_esc(line.source)}');
+          final mmKey = line.mm.trim().toLowerCase();
+          if (mmKey.isEmpty) continue;
+          final match = flaggedLookup[mmKey];
+          if (match != null) {
+            matchedFlagged.putIfAbsent(mmKey, () => match);
+          }
         }
+      }
+    }
+    if (matchedFlagged.isNotEmpty) {
+      sb.writeln();
+      sb.writeln(
+          'flagged_mm,name,alternative_available,alternative_mm,alternative_name,note,flagged_at,flagged_by');
+      final flaggedList = matchedFlagged.values.toList()
+        ..sort((a, b) => a.mm.toLowerCase().compareTo(b.mm.toLowerCase()));
+      for (final flagged in flaggedList) {
+        final alternativeAvailable = flagged.alternativeAvailable ? 'true' : 'false';
+        final alternativeMm = flagged.alternativeMm ?? '';
+        final alternativeName = flagged.alternativeName ?? '';
+        final note = flagged.note ?? '';
+        final flaggedAt = flagged.flaggedAt?.toIso8601String() ?? '';
+        final flaggedBy = flagged.flaggedBy ?? '';
+        sb.writeln(
+            '${_esc(flagged.mm)},${_esc(flagged.name)},${_esc(alternativeAvailable)},${_esc(alternativeMm)},${_esc(alternativeName)},${_esc(note)},${_esc(flaggedAt)},${_esc(flaggedBy)}');
       }
     }
     return sb.toString();
   }
 
   /// Writes the CSV to the given file path.
-  Future<void> writeCsv(String path, List<WorkLocation> locations, List<StandardDef> standards) async {
-    final csv = buildCsv(locations, standards);
+  Future<void> writeCsv(
+    String path,
+    List<WorkLocation> locations,
+    List<StandardDef> standards, {
+    List<FlaggedMaterial> flaggedMaterials = const [],
+  }) async {
+    final csv = buildCsv(
+      locations,
+      standards,
+      flaggedMaterials: flaggedMaterials,
+    );
     final file = File(path);
     await file.writeAsString(csv);
   }

--- a/lib/ui/project_screen.dart
+++ b/lib/ui/project_screen.dart
@@ -238,8 +238,13 @@ class _ProjectScreenState extends State<ProjectScreen> {
   Future<void> _exportCsv() async {
     final repo = await createRepo();
     final standards = await repo.listStandards();
+    final flaggedMaterials = await repo.loadFlaggedMaterials();
     final exporter = BomExporter();
-    final csv = exporter.buildCsv(locations, standards);
+    final csv = exporter.buildCsv(
+      locations,
+      standards,
+      flaggedMaterials: flaggedMaterials,
+    );
     const csvTypeGroup = XTypeGroup(
       label: 'CSV',
       extensions: <String>['csv'],

--- a/test/bom_export_test.dart
+++ b/test/bom_export_test.dart
@@ -3,7 +3,7 @@ import 'package:bom_builder/core/models.dart';
 import 'package:bom_builder/core/bom_exporter.dart';
 
 void main() {
-  test('buildCsv aggregates location BOM', () {
+  test('buildCsv aggregates location BOM without flagged section', () {
     final std1 = StandardDef(
       code: 'S1',
       name: 'Std1',
@@ -32,5 +32,78 @@ void main() {
     expect(lines.contains('L1,S1,MM1,1,static'), isTrue);
     expect(lines.contains('L2,S1,MM1,1,static'), isTrue);
     expect(lines.contains('L2,S2,MM2,2,rule:Conn'), isTrue);
+    expect(lines.contains(
+      'flagged_mm,name,alternative_available,alternative_mm,alternative_name,note,flagged_at,flagged_by',
+    ),
+        isFalse);
+  });
+
+  test('buildCsv appends flagged materials section when matches exist', () {
+    final std1 = StandardDef(
+      code: 'S1',
+      name: 'Std1',
+      staticComponents: [StaticComponent(mm: 'MM1', qty: 1)],
+    );
+    final std2 = StandardDef(
+      code: 'S2',
+      name: 'Std2',
+      dynamicComponents: [
+        DynamicComponentDef(name: 'Conn', rules: [
+          RuleDef(expr: {'==': [1, 1]}, outputs: [OutputSpec(mm: 'MM2', qty: 2)])
+        ])
+      ],
+    );
+
+    final locations = [
+      WorkLocation(barcode: 'L1', standards: {'S1', 'S2'}),
+    ];
+
+    final flagged = [
+      FlaggedMaterial(
+        mm: 'mm2',
+        name: 'Dynamic Material',
+        alternativeAvailable: true,
+        alternativeMm: 'ALT-2',
+        alternativeName: 'Alt Material',
+        note: 'Use alternative',
+        flaggedAt: DateTime.utc(2023, 1, 1),
+        flaggedBy: 'Inspector',
+      ),
+      FlaggedMaterial(
+        mm: 'mm1',
+        name: 'Static Material',
+        note: 'Discontinue',
+        flaggedBy: 'QA',
+      ),
+      const FlaggedMaterial(mm: 'MMX', name: 'Unused'),
+    ];
+
+    final exporter = BomExporter();
+    final csv = exporter.buildCsv(
+      locations,
+      [std1, std2],
+      flaggedMaterials: flagged,
+    );
+    final lines = csv.trim().split('\n');
+
+    expect(lines.first, 'location,standard,mm,qty,source');
+    expect(lines.contains('L1,S1,MM1,1,static'), isTrue);
+    expect(lines.contains('L1,S2,MM2,2,rule:Conn'), isTrue);
+
+    final headerLine =
+        'flagged_mm,name,alternative_available,alternative_mm,alternative_name,note,flagged_at,flagged_by';
+    final headerIndex = lines.indexOf(headerLine);
+    expect(headerIndex, greaterThan(0));
+    expect(lines[headerIndex - 1], '');
+
+    expect(
+      lines[headerIndex + 1],
+      'mm1,Static Material,false,,,Discontinue,,QA',
+    );
+    expect(
+      lines[headerIndex + 2],
+      'mm2,Dynamic Material,true,ALT-2,Alt Material,Use alternative,2023-01-01T00:00:00.000Z,Inspector',
+    );
+    expect(lines.any((line) => line.contains('MMX')), isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- extend the BOM exporter to include a flagged materials section when exported lines match tracked materials
- load flagged materials from the repo when exporting a project CSV
- add tests covering the new flagged section behavior

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1943b7cec8326871325e1c49d07bf