### PR TITLE
Add file locking for LocalStandardsRepo writes

### DIFF
--- a/test/local_repo_test.dart
+++ b/test/local_repo_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -54,5 +55,64 @@ void main() {
     expect(loaded.length, 2);
     expect(loaded.first.key, params.first.key);
     expect(loaded[1].allowedValues, ['Red', 'Blue']);
+  });
+
+  test('concurrent saves serialize without data loss', () async {
+    final repoA = LocalStandardsRepo();
+    final repoB = LocalStandardsRepo();
+    const code = 'CONCURRENT_STD';
+
+    final futures = <Future<void>>[];
+    for (var i = 0; i < 20; i++) {
+      futures.add(
+        repoA.saveStandard(
+          StandardDef(
+            code: code,
+            name: 'RepoA-$i',
+            parameters: [
+              ParameterDef(key: 'A-$i', type: ParamType.text),
+            ],
+          ),
+        ),
+      );
+      futures.add(
+        repoB.saveStandard(
+          StandardDef(
+            code: code,
+            name: 'RepoB-$i',
+            parameters: [
+              ParameterDef(key: 'B-$i', type: ParamType.text),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await Future.wait(futures);
+
+    final standards = await repoA.listStandards();
+    expect(standards, hasLength(1));
+    final standard = standards.single;
+    expect(standard.code, code);
+    expect(
+      standard.name,
+      anyOf([
+        for (var i = 0; i < 20; i++) 'RepoA-$i',
+        for (var i = 0; i < 20; i++) 'RepoB-$i',
+      ]),
+    );
+    expect(standard.parameters, hasLength(1));
+    expect(
+      standard.parameters.single.key,
+      anyOf([
+        for (var i = 0; i < 20; i++) 'A-$i',
+        for (var i = 0; i < 20; i++) 'B-$i',
+      ]),
+    );
+
+    final file = File('${tempDir.path}/bom_data/standards/$code.json');
+    expect(await file.exists(), isTrue);
+    final decoded = jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+    expect(() => StandardDef.fromJson(decoded), returnsNormally);
   });
 }


### PR DESCRIPTION
## Summary
- add a helper to lock sibling `.lock` files before mutating JSON persistence
- wrap LocalStandardsRepo save and delete operations with the locking helper
- add an integration test that exercises concurrent saves against the same repo directory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f8aa0208326beddfe0fc44c5bb0