### PR TITLE
Implement flagged materials merge workflow and tests

### DIFF
--- a/lib/data/repo.dart
+++ b/lib/data/repo.dart
@@ -12,11 +12,60 @@ abstract class StandardsRepo {
   Future<void> saveGlobalDynamicComponents(List<DynamicComponentDef> components);
 
   Future<List<FlaggedMaterial>> loadFlaggedMaterials();
-  Future<void> saveFlaggedMaterials(List<FlaggedMaterial> materials);
+  Future<FlaggedMaterialsSaveResult> saveFlaggedMaterials(
+      FlaggedMaterialsSaveRequest request);
 
   Future<void> saveCacheEntry(String key, Map<String, dynamic> entryJson);
   Future<Map<String, dynamic>?> getCacheEntry(String key);
   Future<Map<String, Map<String, dynamic>>> listPendingCache();
   Future<void> approveCache(String key);
   Future<void> rejectCache(String key);
+}
+
+class FlaggedMaterialsSaveRequest {
+  final List<FlaggedMaterial> original;
+  final List<FlaggedMaterial> updated;
+
+  const FlaggedMaterialsSaveRequest({
+    required this.original,
+    required this.updated,
+  });
+}
+
+enum FlaggedMaterialConflictType { addition, removal, field }
+
+class FlaggedMaterialConflict {
+  final String mm;
+  final FlaggedMaterialConflictType type;
+  final Set<String> fields;
+  final FlaggedMaterial? original;
+  final FlaggedMaterial? local;
+  final FlaggedMaterial? remote;
+
+  const FlaggedMaterialConflict({
+    required this.mm,
+    required this.type,
+    this.fields = const {},
+    this.original,
+    this.local,
+    this.remote,
+  });
+}
+
+class FlaggedMaterialsSaveResult {
+  final List<FlaggedMaterial> merged;
+  final List<FlaggedMaterialConflict> conflicts;
+  final Set<String> remoteChanges;
+  final bool wroteFile;
+
+  const FlaggedMaterialsSaveResult({
+    required this.merged,
+    required this.conflicts,
+    required this.remoteChanges,
+    required this.wroteFile,
+  });
+
+  bool get didSave => conflicts.isEmpty;
+  bool get hasConflicts => conflicts.isNotEmpty;
+  bool get hasRemoteChanges => remoteChanges.isNotEmpty;
 }

--- a/lib/data/web_repo.dart
+++ b/lib/data/web_repo.dart
@@ -123,12 +123,20 @@ class WebStandardsRepo implements StandardsRepo {
   }
 
   @override
-  Future<void> saveFlaggedMaterials(List<FlaggedMaterial> materials) async {
+  Future<FlaggedMaterialsSaveResult> saveFlaggedMaterials(
+      FlaggedMaterialsSaveRequest request) async {
+    final items = request.updated;
     _setMap(
       _kFlaggedMaterials,
       {
-        'items': materials.map((e) => e.toJson()).toList(),
+        'items': items.map((e) => e.toJson()).toList(),
       },
+    );
+    return FlaggedMaterialsSaveResult(
+      merged: List<FlaggedMaterial>.from(items),
+      conflicts: const [],
+      remoteChanges: const {},
+      wroteFile: true,
     );
   }
 

--- a/test/flagged_materials_merge_test.dart
+++ b/test/flagged_materials_merge_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bom_builder/core/models.dart';
+import 'package:bom_builder/data/local_repo.dart';
+
+void main() {
+  group('Flagged materials merge', () {
+    test('merges disjoint local and remote updates', () {
+      final original = [
+        const FlaggedMaterial(mm: 'MM1', name: 'Original', note: 'Base'),
+      ];
+      final updated = [
+        const FlaggedMaterial(mm: 'MM1', name: 'Local change', note: 'Base'),
+      ];
+      final remote = [
+        const FlaggedMaterial(mm: 'MM1', name: 'Original', note: 'Remote note'),
+      ];
+
+      final plan = LocalStandardsRepo.planFlaggedMaterialsMerge(
+        original: original,
+        updated: updated,
+        remote: remote,
+      );
+
+      expect(plan.conflicts, isEmpty);
+      expect(plan.merged, hasLength(1));
+      expect(plan.merged.single.name, 'Local change');
+      expect(plan.merged.single.note, 'Remote note');
+      expect(plan.remoteChanges, contains('MM1'));
+      expect(plan.needsWrite, isTrue);
+    });
+
+    test('detects conflicts when both sides edit the same field', () {
+      final original = [
+        const FlaggedMaterial(mm: 'MM2', name: 'Original', note: 'Note'),
+      ];
+      final updated = [
+        const FlaggedMaterial(mm: 'MM2', name: 'Local edit', note: 'Note'),
+      ];
+      final remote = [
+        const FlaggedMaterial(mm: 'MM2', name: 'Remote edit', note: 'Note'),
+      ];
+
+      final plan = LocalStandardsRepo.planFlaggedMaterialsMerge(
+        original: original,
+        updated: updated,
+        remote: remote,
+      );
+
+      expect(plan.conflicts, hasLength(1));
+      final conflict = plan.conflicts.single;
+      expect(conflict.mm, 'MM2');
+      expect(conflict.type, FlaggedMaterialConflictType.field);
+      expect(conflict.fields, contains('name'));
+      expect(plan.needsWrite, isFalse);
+      expect(plan.remoteChanges, contains('MM2'));
+      expect(plan.merged.single.name, 'Remote edit');
+    });
+
+    test('accepts remote removals when the local entry is untouched', () {
+      final original = [
+        const FlaggedMaterial(mm: 'MM3', name: 'To remove'),
+      ];
+      final updated = [
+        const FlaggedMaterial(mm: 'MM3', name: 'To remove'),
+      ];
+      final remote = <FlaggedMaterial>[];
+
+      final plan = LocalStandardsRepo.planFlaggedMaterialsMerge(
+        original: original,
+        updated: updated,
+        remote: remote,
+      );
+
+      expect(plan.conflicts, isEmpty);
+      expect(plan.merged, isEmpty);
+      expect(plan.needsWrite, isFalse);
+      expect(plan.remoteChanges, contains('MM3'));
+    });
+  });
+}

--- a/test/flagged_materials_screen_test.dart
+++ b/test/flagged_materials_screen_test.dart
@@ -1,0 +1,109 @@
+import 'package:bom_builder/core/models.dart';
+import 'package:bom_builder/data/repo.dart';
+import 'package:bom_builder/ui/flagged_materials_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeRepo implements StandardsRepo {
+  _FakeRepo({required this.initial, required this.saveResult});
+
+  final List<FlaggedMaterial> initial;
+  final FlaggedMaterialsSaveResult saveResult;
+  FlaggedMaterialsSaveRequest? lastRequest;
+
+  @override
+  Future<List<FlaggedMaterial>> loadFlaggedMaterials() async => initial;
+
+  @override
+  Future<FlaggedMaterialsSaveResult> saveFlaggedMaterials(
+    FlaggedMaterialsSaveRequest request,
+  ) async {
+    lastRequest = request;
+    return saveResult;
+  }
+
+  @override
+  Future<List<StandardDef>> listStandards() async => throw UnimplementedError();
+
+  @override
+  Future<void> saveStandard(StandardDef std) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteStandard(String code) async => throw UnimplementedError();
+
+  @override
+  Future<List<ParameterDef>> loadGlobalParameters() async => throw UnimplementedError();
+
+  @override
+  Future<void> saveGlobalParameters(List<ParameterDef> parameters) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<DynamicComponentDef>> loadGlobalDynamicComponents() async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> saveGlobalDynamicComponents(
+          List<DynamicComponentDef> components) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> saveCacheEntry(String key, Map<String, dynamic> entryJson) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getCacheEntry(String key) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, Map<String, dynamic>>> listPendingCache() async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> approveCache(String key) async => throw UnimplementedError();
+
+  @override
+  Future<void> rejectCache(String key) async => throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('shows a conflict dialog when merges fail', (tester) async {
+    final original = const FlaggedMaterial(mm: 'MM10', name: 'Original', note: 'Base');
+    final remote = const FlaggedMaterial(mm: 'MM10', name: 'Remote', note: 'Remote note');
+    final conflict = FlaggedMaterialConflict(
+      mm: original.mm,
+      type: FlaggedMaterialConflictType.field,
+      fields: const {'note'},
+      original: original,
+      local: const FlaggedMaterial(mm: 'MM10', name: 'Original', note: 'Local note'),
+      remote: remote,
+    );
+    final repo = _FakeRepo(
+      initial: [original],
+      saveResult: FlaggedMaterialsSaveResult(
+        merged: [remote],
+        conflicts: [conflict],
+        remoteChanges: const {'MM10'},
+        wroteFile: false,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FlaggedMaterialsScreen(
+          repoBuilder: () async => repo,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save changes'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Conflicts detected'), findsOneWidget);
+    expect(find.textContaining('MM10'), findsWidgets);
+    expect(repo.lastRequest, isNotNull);
+    expect(repo.lastRequest!.original.single.mm, original.mm);
+  });
+}


### PR DESCRIPTION
## Summary
- add merge planning for flagged materials saves with conflict detection
- update the flagged materials screen to surface merge/conflict dialogs and reload merged data
- add unit and widget coverage around the new merge helper and conflict UI

## Testing
- Not run (flutter binary unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1a2225934832685598d80e339a9a8