### PR TITLE
Support dynamic MM providers for static components

### DIFF
--- a/lib/core/engine.dart
+++ b/lib/core/engine.dart
@@ -10,35 +10,81 @@ class RuleEngine {
   List<BomLine> evaluate(StandardDef std, Map<String, dynamic> inputs) {
     final bom = <BomLine>[];
 
+    final dynamicByName = <String, DynamicComponentDef>{};
+    for (final dc in std.dynamicComponents) {
+      final name = dc.name.trim();
+      if (name.isEmpty) continue;
+      dynamicByName[name] = dc;
+    }
+
+    final selectedRules = <DynamicComponentDef, RuleDef?>{};
+
+    RuleDef? selectRule(DynamicComponentDef dc) {
+      if (selectedRules.containsKey(dc)) {
+        return selectedRules[dc];
+      }
+      final rule = _selectRule(dc, inputs);
+      selectedRules[dc] = rule;
+      return rule;
+    }
+
     // static
     for (final sc in std.staticComponents) {
-      bom.add(BomLine(mm: sc.mm, qty: sc.qty, source: 'static'));
+      final providerName = sc.dynamicMmComponent?.trim();
+      if (providerName != null && providerName.isNotEmpty) {
+        final provider = dynamicByName[providerName];
+        final mm = provider != null ? _firstNonEmptyMm(selectRule(provider)) : null;
+        if (mm != null) {
+          bom.add(BomLine(mm: mm, qty: sc.qty, source: 'static:$providerName'));
+          continue;
+        }
+      }
+      final literalMm = sc.mm;
+      if (literalMm != null) {
+        bom.add(BomLine(mm: literalMm, qty: sc.qty, source: 'static'));
+      }
     }
+
+    final numericInputs = _onlyNums(inputs);
 
     // dynamic
     for (final dc in std.dynamicComponents) {
-      final matches = <RuleDef>[];
-      for (final r in dc.rules) {
-        final ok = _logic.apply(r.expr, inputs);
-        if (ok == true) matches.add(r);
-      }
-      if (matches.isEmpty) continue;
-
-      matches.sort((a, b) {
-        final p = (b.priority) - (a.priority);
-        if (p != 0) return p;
-        final la = jsonEncode(a.expr).length;
-        final lb = jsonEncode(b.expr).length;
-        return lb - la; // more specific first
-      });
-
-      final chosen = matches.first;
+      final chosen = selectRule(dc);
+      if (chosen == null) continue;
       for (final out in chosen.outputs) {
-        final qty = out.qty ?? QtyFormula.evalInt(out.qtyFormula ?? '1', _onlyNums(inputs));
+        final qty = out.qty ?? QtyFormula.evalInt(out.qtyFormula ?? '1', numericInputs);
         bom.add(BomLine(mm: out.mm, qty: qty, source: 'rule:${dc.name}'));
       }
     }
     return bom;
+  }
+
+  RuleDef? _selectRule(DynamicComponentDef dc, Map<String, dynamic> inputs) {
+    final matches = <RuleDef>[];
+    for (final r in dc.rules) {
+      final ok = _logic.apply(r.expr, inputs);
+      if (ok == true) matches.add(r);
+    }
+    if (matches.isEmpty) return null;
+
+    matches.sort((a, b) {
+      final p = (b.priority) - (a.priority);
+      if (p != 0) return p;
+      final la = jsonEncode(a.expr).length;
+      final lb = jsonEncode(b.expr).length;
+      return lb - la; // more specific first
+    });
+
+    return matches.first;
+  }
+
+  String? _firstNonEmptyMm(RuleDef? rule) {
+    if (rule == null) return null;
+    for (final out in rule.outputs) {
+      final mm = out.mm.trim();
+      if (mm.isNotEmpty) return mm;
+    }
+    return null;
   }
 
   Map<String, num> _onlyNums(Map<String, dynamic> src) {

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -84,14 +84,24 @@ class ParameterDef {
 }
 
 class StaticComponent {
-  final String mm;
+  final String? mm;
+  final String? dynamicMmComponent;
   final int qty;
-  StaticComponent({required this.mm, required this.qty});
+
+  const StaticComponent({this.mm, this.dynamicMmComponent, required this.qty});
+
   factory StaticComponent.fromJson(Map<String, dynamic> j) => StaticComponent(
-        mm: j['mm'] as String,
+        mm: j['mm'] as String?,
+        dynamicMmComponent: j['dynamic_mm_component'] as String?,
         qty: (j['qty'] as num).toInt(),
       );
-  Map<String, dynamic> toJson() => {'mm': mm, 'qty': qty};
+
+  Map<String, dynamic> toJson() => {
+        if (mm != null) 'mm': mm,
+        if (dynamicMmComponent != null)
+          'dynamic_mm_component': dynamicMmComponent,
+        'qty': qty,
+      };
 }
 
 class FlaggedMaterial {
@@ -287,7 +297,7 @@ class StandardApplication {
 class BomLine {
   final String mm;
   final int qty;
-  final String source; // 'static' or 'rule:<dc>'
+  final String source; // 'static', 'static:<dc>' or 'rule:<dc>'
   BomLine({required this.mm, required this.qty, required this.source});
 }
 


### PR DESCRIPTION
## Summary
- allow `StaticComponent` to store either a literal MM or a dynamic component reference when serializing
- teach the rule engine to reuse dynamic components to resolve static MM selections while keeping static quantities
- update the standards manager static component editor to pick literal or dynamic MM values and add a regression test for the new flow

## Testing
- flutter test *(fails: `flutter` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a23b04388326b88e5b910ad30b45