### PR TITLE
Ensure static components include dynamic dependencies

### DIFF
--- a/lib/ui/project_screen.dart
+++ b/lib/ui/project_screen.dart
@@ -239,11 +239,14 @@ class _ProjectScreenState extends State<ProjectScreen> {
     final repo = await createRepo();
     final standards = await repo.listStandards();
     final flaggedMaterials = await repo.loadFlaggedMaterials();
+    final globalDynamicComponents =
+        await repo.loadGlobalDynamicComponents();
     final exporter = BomExporter();
     final csv = exporter.buildCsv(
       locations,
       standards,
       flaggedMaterials: flaggedMaterials,
+      globalDynamicComponents: globalDynamicComponents,
     );
     const csvTypeGroup = XTypeGroup(
       label: 'CSV',

--- a/test/bom_export_test.dart
+++ b/test/bom_export_test.dart
@@ -106,4 +106,42 @@ void main() {
     );
     expect(lines.any((line) => line.contains('MMX')), isFalse);
   });
+
+  test('buildCsv resolves dynamic references in static components', () {
+    final std = StandardDef(
+      code: 'S1',
+      name: 'Std1',
+      staticComponents: [
+        const StaticComponent(dynamicMmComponent: 'Conn', qty: 3),
+      ],
+    );
+
+    final globalDynamic = DynamicComponentDef(
+      name: 'Conn',
+      rules: [
+        RuleDef(
+          expr: {'==': [1, 1]},
+          outputs: [
+            OutputSpec(mm: 'MM2', qty: 5),
+          ],
+        ),
+      ],
+    );
+
+    final locations = [
+      WorkLocation(barcode: 'L1', standards: {'S1'}),
+    ];
+
+    final exporter = BomExporter();
+    final csv = exporter.buildCsv(
+      locations,
+      [std],
+      globalDynamicComponents: [globalDynamic],
+    );
+
+    final lines = csv.trim().split('\n');
+
+    expect(lines.contains('L1,S1,MM2,3,static:Conn'), isTrue);
+    expect(lines.contains('L1,S1,MM2,5,rule:Conn'), isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- ensure global data loads trigger dependency resolution for static components referencing dynamic MMs
- automatically add referenced dynamic components and parameters when a static component targets a dynamic MM
- reuse the dependency logic whenever a static component changes to keep the selection list up to date
- include global dynamic component definitions during BOM export so static references resolve to the expected materials
- cover the BOM exporter with a unit test verifying static components that depend on dynamic definitions

## Testing
- not run (flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d2b4ca81fc8326b543154487eb4cf7