### PR TITLE
Ensure static rows remain when suppressing injected dynamics

### DIFF
--- a/lib/core/bom_exporter.dart
+++ b/lib/core/bom_exporter.dart
@@ -22,22 +22,95 @@ class BomExporter {
       flaggedLookup[key] = flagged;
     }
     final matchedFlagged = <String, FlaggedMaterial>{};
+    final standardsByCode = <String, StandardDef>{};
+    for (final std in standards) {
+      standardsByCode[std.code] = std;
+    }
+    final dynamicLookup = _buildDynamicComponentLookup(standards);
+    final standardsWithDependencies = <String, StandardDef>{};
+    final injectedDynamicNames = <String, Set<String>>{};
+    for (final entry in standardsByCode.entries) {
+      final resolved =
+          _withDynamicDependencies(entry.value, dynamicLookup);
+      standardsWithDependencies[entry.key] = resolved.standard;
+      injectedDynamicNames[entry.key] = resolved.injectedNames;
+    }
     for (final loc in locations) {
       for (final code in loc.standards) {
-        final std = standards.firstWhere(
-            (s) => s.code == code,
-            orElse: () => StandardDef(code: code, name: ''));
-        if (std.code != code || std.name.isEmpty && std.staticComponents.isEmpty && std.dynamicComponents.isEmpty) {
+        final base = standardsByCode[code];
+        if (base == null) {
           continue;
         }
-        final lines = engine.evaluate(std, loc.variables);
+        if (base.name.isEmpty &&
+            base.staticComponents.isEmpty &&
+            base.dynamicComponents.isEmpty) {
+          continue;
+        }
+        final stdWithDeps = standardsWithDependencies[code] ?? base;
+        final injected = injectedDynamicNames[code] ?? const <String>{};
+        final lines = engine.evaluate(stdWithDeps, loc.variables);
+        final staticConsumersByDynamic = <String, List<StaticComponent>>{};
+        if (base.staticComponents.isNotEmpty && injected.isNotEmpty) {
+          for (final component in base.staticComponents) {
+            final providerName = component.dynamicMmComponent?.trim();
+            if (providerName == null || providerName.isEmpty) {
+              continue;
+            }
+            staticConsumersByDynamic
+                .putIfAbsent(providerName, () => <StaticComponent>[])
+                .add(component);
+          }
+        }
+        final emittedStaticProviders = <String>{};
+        final suppressedDynamicOutputs = <String, BomLine>{};
         for (final line in lines) {
-          sb.writeln('${_esc(loc.barcode)},${_esc(std.code)},${_esc(line.mm)},${line.qty},${_esc(line.source)}');
+          final source = line.source;
+          if (source.startsWith('static:')) {
+            final providerName = source.substring(7).trim();
+            if (providerName.isNotEmpty) {
+              emittedStaticProviders.add(providerName);
+            }
+          }
+          if (source.startsWith('rule:')) {
+            final dynamicName = source.substring(5).trim();
+            if (injected.contains(dynamicName)) {
+              suppressedDynamicOutputs.putIfAbsent(dynamicName, () => line);
+              continue;
+            }
+          }
+          sb.writeln('${_esc(loc.barcode)},${_esc(base.code)},${_esc(line.mm)},${line.qty},${_esc(line.source)}');
           final mmKey = line.mm.trim().toLowerCase();
           if (mmKey.isEmpty) continue;
           final match = flaggedLookup[mmKey];
           if (match != null) {
             matchedFlagged.putIfAbsent(mmKey, () => match);
+          }
+        }
+        if (suppressedDynamicOutputs.isNotEmpty &&
+            staticConsumersByDynamic.isNotEmpty) {
+          for (final entry in suppressedDynamicOutputs.entries) {
+            final dynamicName = entry.key;
+            if (emittedStaticProviders.contains(dynamicName)) {
+              continue;
+            }
+            final consumers = staticConsumersByDynamic[dynamicName];
+            if (consumers == null || consumers.isEmpty) {
+              continue;
+            }
+            final fallbackMm = entry.value.mm;
+            final fallbackSource = 'static:$dynamicName';
+            for (final consumer in consumers) {
+              sb.writeln(
+                  '${_esc(loc.barcode)},${_esc(base.code)},${_esc(fallbackMm)},${consumer.qty},${_esc(fallbackSource)}');
+              final mmKey = fallbackMm.trim().toLowerCase();
+              if (mmKey.isEmpty) {
+                continue;
+              }
+              final match = flaggedLookup[mmKey];
+              if (match != null) {
+                matchedFlagged.putIfAbsent(mmKey, () => match);
+              }
+            }
           }
         }
       }
@@ -84,5 +157,69 @@ class BomExporter {
       return '"$escaped"';
     }
     return v;
+  }
+
+  Map<String, DynamicComponentDef> _buildDynamicComponentLookup(
+      Iterable<StandardDef> standards) {
+    final lookup = <String, DynamicComponentDef>{};
+    for (final std in standards) {
+      for (final component in std.dynamicComponents) {
+        final name = component.name.trim();
+        if (name.isEmpty) continue;
+        lookup.putIfAbsent(name, () => component);
+      }
+    }
+    return lookup;
+  }
+
+  ({StandardDef standard, Set<String> injectedNames})
+      _withDynamicDependencies(
+    StandardDef std,
+    Map<String, DynamicComponentDef> dynamicLookup,
+  ) {
+    if (std.staticComponents.isEmpty) {
+      return (standard: std, injectedNames: const <String>{});
+    }
+    final existing = std.dynamicComponents
+        .map((dc) => dc.name.trim())
+        .where((name) => name.isNotEmpty)
+        .toSet();
+    final injected = <String>{};
+    final dependencies = <DynamicComponentDef>[];
+    for (final staticComponent in std.staticComponents) {
+      final providerName = staticComponent.dynamicMmComponent?.trim();
+      if (providerName == null || providerName.isEmpty) {
+        continue;
+      }
+      if (existing.contains(providerName)) {
+        continue;
+      }
+      final dependency = dynamicLookup[providerName];
+      if (dependency == null) {
+        continue;
+      }
+      dependencies.add(dependency);
+      injected.add(providerName);
+      existing.add(providerName);
+    }
+    if (dependencies.isEmpty) {
+      return (standard: std, injectedNames: const <String>{});
+    }
+    return (
+      standard: StandardDef(
+        code: std.code,
+        name: std.name,
+        version: std.version,
+        status: std.status,
+        parameters: std.parameters,
+        staticComponents: std.staticComponents,
+        dynamicComponents: [
+          ...std.dynamicComponents,
+          ...dependencies,
+        ],
+        applicationId: std.applicationId,
+      ),
+      injectedNames: Set.unmodifiable(injected),
+    );
   }
 }

--- a/test/bom_export_test.dart
+++ b/test/bom_export_test.dart
@@ -106,4 +106,46 @@ void main() {
     );
     expect(lines.any((line) => line.contains('MMX')), isFalse);
   });
+
+  test('static component borrowing global dynamic MM omits rule row', () {
+    final sharedDynamic = DynamicComponentDef(name: 'GlobalConn', rules: [
+      RuleDef(expr: {
+        '==': [1, 1]
+      }, outputs: [OutputSpec(mm: 'MM#GLOBAL', qty: 3)])
+    ]);
+    final stdPrimary = StandardDef(
+      code: 'PRIMARY',
+      name: 'Primary',
+      staticComponents: [
+        StaticComponent(dynamicMmComponent: 'GlobalConn', qty: 3),
+      ],
+      dynamicComponents: [
+        DynamicComponentDef(name: 'LocalDyn', rules: [
+          RuleDef(expr: {
+            '==': [1, 1]
+          }, outputs: [OutputSpec(mm: 'MM#LOCAL', qty: 7)])
+        ]),
+      ],
+    );
+    final library = StandardDef(
+      code: 'LIB',
+      name: 'Library',
+      dynamicComponents: [sharedDynamic],
+    );
+
+    final locations = [
+      WorkLocation(barcode: 'L-100', standards: {'PRIMARY'}),
+    ];
+
+    final exporter = BomExporter();
+    final csv = exporter.buildCsv(locations, [stdPrimary, library]);
+    final lines = csv.trim().split('\n');
+
+    expect(lines.contains('L-100,PRIMARY,MM#GLOBAL,3,static:GlobalConn'), isTrue);
+    expect(lines.contains('L-100,PRIMARY,MM#LOCAL,7,rule:LocalDyn'), isTrue);
+    expect(lines.any((line) => line.contains('rule:GlobalConn')), isFalse);
+    final globalLines =
+        lines.where((line) => line.contains('MM#GLOBAL')).toList();
+    expect(globalLines, ['L-100,PRIMARY,MM#GLOBAL,3,static:GlobalConn']);
+  });
 }


### PR DESCRIPTION
## Summary
- capture suppressed outputs for injected dynamic components so their borrowing static components can still emit MM rows without duplicating dynamic rule lines
- keep flagged material tracking for these synthesized rows and avoid re-adding entries when the static line already exists
- tighten the BOM export regression to verify the borrowed global MM only appears as a static row

## Testing
- flutter test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c138ce088326b6a0af7e24377bd5