### PR TITLE
Add connector matrix workflow for dynamic components

### DIFF
--- a/lib/core/engine.dart
+++ b/lib/core/engine.dart
@@ -18,6 +18,7 @@ class RuleEngine {
     }
 
     final selectedRules = <DynamicComponentDef, RuleDef?>{};
+    final matrixSelections = <DynamicComponentDef, _MatrixSelection>{};
 
     RuleDef? selectRule(DynamicComponentDef dc) {
       if (selectedRules.containsKey(dc)) {
@@ -28,12 +29,23 @@ class RuleEngine {
       return rule;
     }
 
+    _MatrixSelection matrixSelection(DynamicComponentDef dc) {
+      return matrixSelections.putIfAbsent(dc, () => _selectMatrix(dc, inputs));
+    }
+
     // static
     for (final sc in std.staticComponents) {
       final providerName = sc.dynamicMmComponent?.trim();
       if (providerName != null && providerName.isNotEmpty) {
         final provider = dynamicByName[providerName];
-        final mm = provider != null ? _firstNonEmptyMm(selectRule(provider)) : null;
+        String? mm;
+        if (provider != null) {
+          final matrixResult = matrixSelection(provider);
+          if (matrixResult.status == 'ok' && matrixResult.mm != null) {
+            mm = matrixResult.mm;
+          }
+        }
+        mm ??= provider != null ? _firstNonEmptyMm(selectRule(provider)) : null;
         if (mm != null) {
           bom.add(BomLine(mm: mm, qty: sc.qty, source: 'static:$providerName'));
           continue;
@@ -49,6 +61,22 @@ class RuleEngine {
 
     // dynamic
     for (final dc in std.dynamicComponents) {
+      final matrixResult = matrixSelection(dc);
+      if (matrixResult.shouldEmitLine) {
+        bom.add(
+          BomLine(
+            mm: matrixResult.mm ?? 'INVALID',
+            qty: matrixResult.qty,
+            source: 'matrix:${dc.name}',
+            status: matrixResult.status,
+            requiresAccessory: matrixResult.requiresAccessory,
+            notes: matrixResult.notes,
+          ),
+        );
+      }
+      if (matrixResult.blockRules) {
+        continue;
+      }
       final chosen = selectRule(dc);
       if (chosen == null) continue;
       for (final out in chosen.outputs) {
@@ -99,4 +127,140 @@ class RuleEngine {
     }
     return m;
   }
+
+  _MatrixSelection _selectMatrix(
+    DynamicComponentDef dc,
+    Map<String, dynamic> inputs,
+  ) {
+    final matrix = dc.matrix;
+    if (matrix == null) {
+      return _MatrixSelection.none();
+    }
+    final axis1Value = matrix.valueForAxis(matrix.axis1Parameter, inputs);
+    final axis2Value = matrix.valueForAxis(matrix.axis2Parameter, inputs);
+    if (axis1Value == null || axis1Value.isEmpty || axis2Value == null || axis2Value.isEmpty) {
+      return _MatrixSelection(
+        status: 'pending',
+        qty: 0,
+        requiresAccessory: false,
+        notes: null,
+        blockRules: false,
+        shouldEmitLine: false,
+        mm: null,
+      );
+    }
+    final cell = matrix.lookup(inputs);
+    if (cell == null) {
+      final note = 'No combination for $axis1Value × $axis2Value';
+      return _MatrixSelection(
+        status: 'invalid',
+        qty: 0,
+        requiresAccessory: false,
+        notes: note,
+        blockRules: true,
+        shouldEmitLine: true,
+        mm: 'INVALID',
+      );
+    }
+    if (!cell.enabled) {
+      final note = cell.notes?.isNotEmpty == true
+          ? cell.notes
+          : 'Combination $axis1Value × $axis2Value disabled';
+      return _MatrixSelection(
+        status: 'invalid',
+        qty: 0,
+        requiresAccessory: cell.requiresAccessory,
+        notes: note,
+        blockRules: true,
+        shouldEmitLine: true,
+        mm: 'INVALID',
+      );
+    }
+    final mm = _resolveMatrixMm(dc, matrix, inputs, cell);
+    if (mm == null || mm.isEmpty) {
+      return _MatrixSelection(
+        status: 'pending',
+        qty: cell.qty,
+        requiresAccessory: cell.requiresAccessory,
+        notes: cell.notes,
+        blockRules: false,
+        shouldEmitLine: false,
+        mm: null,
+      );
+    }
+    return _MatrixSelection(
+      status: 'ok',
+      qty: cell.qty,
+      requiresAccessory: cell.requiresAccessory,
+      notes: cell.notes,
+      blockRules: false,
+      shouldEmitLine: true,
+      mm: mm,
+    );
+  }
+
+  String? _resolveMatrixMm(
+    DynamicComponentDef dc,
+    ConnectorMatrix matrix,
+    Map<String, dynamic> inputs,
+    ConnectorMatrixCell cell,
+  ) {
+    if (cell.hasMm) {
+      return cell.mm?.trim();
+    }
+    final pattern = dc.mmPattern;
+    if (pattern == null || pattern.trim().isEmpty) {
+      return null;
+    }
+    final axis1Value = matrix.valueForAxis(matrix.axis1Parameter, inputs) ?? '';
+    final axis2Value = matrix.valueForAxis(matrix.axis2Parameter, inputs) ?? '';
+    final resolved = pattern.replaceAllMapped(
+      RegExp(r'\{([^}]+)\}'),
+      (match) {
+        final token = (match.group(1) ?? '').trim();
+        if (token.isEmpty) return '';
+        if (token == 'axis1') return axis1Value;
+        if (token == 'axis2') return axis2Value;
+        if (token == matrix.axis1Parameter) return axis1Value;
+        if (token == matrix.axis2Parameter) return axis2Value;
+        if (token == 'mm') return cell.mm ?? '';
+        final fromInputs = matrix.valueForAxis(token, inputs);
+        if (fromInputs != null) return fromInputs;
+        final raw = inputs[token];
+        return raw == null ? '' : '$raw';
+      },
+    );
+    final trimmed = resolved.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+class _MatrixSelection {
+  final String status;
+  final int qty;
+  final bool requiresAccessory;
+  final String? notes;
+  final bool blockRules;
+  final bool shouldEmitLine;
+  final String? mm;
+
+  const _MatrixSelection({
+    required this.status,
+    required this.qty,
+    required this.requiresAccessory,
+    required this.notes,
+    required this.blockRules,
+    required this.shouldEmitLine,
+    required this.mm,
+  });
+
+  factory _MatrixSelection.none() => const _MatrixSelection(
+        status: 'none',
+        qty: 0,
+        requiresAccessory: false,
+        notes: null,
+        blockRules: false,
+        shouldEmitLine: false,
+        mm: null,
+      );
 }

--- a/lib/ui/dynamic_component_rules_screen.dart
+++ b/lib/ui/dynamic_component_rules_screen.dart
@@ -23,11 +23,97 @@ class DynamicComponentRulesScreen extends StatefulWidget {
 class _DynamicComponentRulesScreenState
     extends State<DynamicComponentRulesScreen> {
   late List<RuleDef> _rules;
+  late ConnectorMatrix _matrix;
+  late Set<String> _matrixColumns;
+  late TextEditingController _axis1Controller;
+  late TextEditingController _axis2Controller;
+  late TextEditingController _mmPatternController;
+  bool _suspendAxisListeners = false;
 
   @override
   void initState() {
     super.initState();
     _rules = widget.component.rules.map((e) => e).toList();
+    final existingMatrix = widget.component.matrix ??
+        const ConnectorMatrix(axis1Parameter: '', axis2Parameter: '', rows: []);
+    _matrix = existingMatrix;
+    _matrixColumns = {...existingMatrix.columnValues};
+    _axis1Controller =
+        TextEditingController(text: existingMatrix.axis1Parameter);
+    _axis2Controller =
+        TextEditingController(text: existingMatrix.axis2Parameter);
+    _mmPatternController =
+        TextEditingController(text: widget.component.mmPattern ?? '');
+    _axis1Controller.addListener(_handleAxisControllersChanged);
+    _axis2Controller.addListener(_handleAxisControllersChanged);
+  }
+
+  @override
+  void dispose() {
+    _axis1Controller.removeListener(_handleAxisControllersChanged);
+    _axis2Controller.removeListener(_handleAxisControllersChanged);
+    _axis1Controller.dispose();
+    _axis2Controller.dispose();
+    _mmPatternController.dispose();
+    super.dispose();
+  }
+
+  void _handleAxisControllersChanged() {
+    if (_suspendAxisListeners) return;
+    final axis1 = _axis1Controller.text.trim();
+    final axis2 = _axis2Controller.text.trim();
+    setState(() {
+      _matrix = _matrix.copyWith(
+        axis1Parameter: axis1,
+        axis2Parameter: axis2,
+      );
+    });
+  }
+
+  void _updateMatrix(ConnectorMatrix newMatrix, {bool updateControllers = false}) {
+    setState(() {
+      _matrix = newMatrix;
+      _matrixColumns = {...newMatrix.columnValues};
+    });
+    if (updateControllers) {
+      _suspendAxisListeners = true;
+      _axis1Controller.text = newMatrix.axis1Parameter;
+      _axis2Controller.text = newMatrix.axis2Parameter;
+      _suspendAxisListeners = false;
+    }
+  }
+
+  List<String> _sortedColumns() {
+    final list = _matrixColumns.toList()
+      ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return list;
+  }
+
+  ConnectorMatrix? _matrixForSave() {
+    final rows = <ConnectorMatrixRow>[];
+    for (final row in _matrix.rows) {
+      final cleanedCells = <ConnectorMatrixCell>[];
+      for (final cell in row.cells) {
+        final hasData = cell.hasMm ||
+            !cell.enabled ||
+            cell.requiresAccessory ||
+            (cell.notes != null && cell.notes!.trim().isNotEmpty) ||
+            cell.qty != 1;
+        if (hasData) {
+          cleanedCells.add(cell);
+        }
+      }
+      if (cleanedCells.isNotEmpty) {
+        rows.add(row.copyWith(cells: cleanedCells));
+      }
+    }
+    final cleaned = _matrix.copyWith(rows: rows);
+    final hasAxisNames = cleaned.axis1Parameter.trim().isNotEmpty ||
+        cleaned.axis2Parameter.trim().isNotEmpty;
+    if (cleaned.rows.isEmpty && !hasAxisNames) {
+      return null;
+    }
+    return cleaned;
   }
 
   Future<void> _addRule() async {
@@ -77,14 +163,722 @@ class _DynamicComponentRulesScreenState
     });
   }
 
+  void _addAxis1Value() {
+    final controller = TextEditingController();
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(
+            'Add ${_matrix.axis1Parameter.isEmpty ? 'Row' : _matrix.axis1Parameter} value'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'e.g. 1/0'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final value = controller.text.trim();
+              Navigator.of(context).pop();
+              if (value.isEmpty) return;
+              final lower = value.toLowerCase();
+              if (_matrix.rows
+                  .any((row) => row.axis1Value.toLowerCase() == lower)) {
+                return;
+              }
+              final columns = _sortedColumns();
+              final cells = [
+                for (final column in columns)
+                  ConnectorMatrixCell(axis2Value: column),
+              ];
+              final rows = [..._matrix.rows, ConnectorMatrixRow(axis1Value: value, cells: cells)]
+                ..sort((a, b) => a.axis1Value
+                    .toLowerCase()
+                    .compareTo(b.axis1Value.toLowerCase()));
+              _updateMatrix(_matrix.copyWith(rows: rows));
+            },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _removeAxis1Value(String value) {
+    final lower = value.toLowerCase();
+    final rows = _matrix.rows
+        .where((row) => row.axis1Value.toLowerCase() != lower)
+        .toList();
+    _updateMatrix(_matrix.copyWith(rows: rows));
+  }
+
+  void _addAxis2Value() {
+    if (_matrix.rows.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Add at least one row before adding columns.')),
+      );
+      return;
+    }
+    final controller = TextEditingController();
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(
+            'Add ${_matrix.axis2Parameter.isEmpty ? 'Column' : _matrix.axis2Parameter} value'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'e.g. 2/0'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final value = controller.text.trim();
+              Navigator.of(context).pop();
+              if (value.isEmpty) return;
+              final lower = value.toLowerCase();
+              if (_matrixColumns.any((c) => c.toLowerCase() == lower)) {
+                return;
+              }
+              final updatedRows = <ConnectorMatrixRow>[];
+              for (final row in _matrix.rows) {
+                final cells = [...row.cells];
+                if (!cells.any(
+                    (cell) => cell.axis2Value.toLowerCase() == lower)) {
+                  cells.add(ConnectorMatrixCell(axis2Value: value));
+                  cells.sort((a, b) => a.axis2Value
+                      .toLowerCase()
+                      .compareTo(b.axis2Value.toLowerCase()));
+                }
+                updatedRows.add(row.copyWith(cells: cells));
+              }
+              _matrixColumns.add(value);
+              _updateMatrix(_matrix.copyWith(rows: updatedRows));
+            },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _removeAxis2Value(String value) {
+    final lower = value.toLowerCase();
+    final updatedRows = <ConnectorMatrixRow>[];
+    for (final row in _matrix.rows) {
+      final filtered = row.cells
+          .where((cell) => cell.axis2Value.toLowerCase() != lower)
+          .toList();
+      updatedRows.add(row.copyWith(cells: filtered));
+    }
+    _matrixColumns.removeWhere((c) => c.toLowerCase() == lower);
+    _updateMatrix(_matrix.copyWith(rows: updatedRows));
+  }
+
+  ConnectorMatrixCell _findCell(String rowValue, String columnValue) {
+    final lowerColumn = columnValue.toLowerCase();
+    final row = _matrix.rows.firstWhere(
+      (r) => r.axis1Value.toLowerCase() == rowValue.toLowerCase(),
+      orElse: () => ConnectorMatrixRow(axis1Value: rowValue),
+    );
+    return row.cells.firstWhere(
+      (cell) => cell.axis2Value.toLowerCase() == lowerColumn,
+      orElse: () => ConnectorMatrixCell(axis2Value: columnValue),
+    );
+  }
+
+  void _setCell(String rowValue, String columnValue, ConnectorMatrixCell cell) {
+    final updatedRows = <ConnectorMatrixRow>[];
+    final targetLower = rowValue.toLowerCase();
+    final columnLower = columnValue.toLowerCase();
+    for (final row in _matrix.rows) {
+      if (row.axis1Value.toLowerCase() != targetLower) {
+        updatedRows.add(row);
+        continue;
+      }
+      final cells = [...row.cells];
+      final idx = cells.indexWhere(
+          (c) => c.axis2Value.toLowerCase() == columnLower);
+      if (idx >= 0) {
+        cells[idx] = cell;
+      } else {
+        cells.add(cell);
+      }
+      cells.sort((a, b) => a.axis2Value
+          .toLowerCase()
+          .compareTo(b.axis2Value.toLowerCase()));
+      updatedRows.add(row.copyWith(cells: cells));
+    }
+    _matrixColumns.add(columnValue);
+    _updateMatrix(_matrix.copyWith(rows: updatedRows));
+  }
+
+  Future<void> _editCell(String rowValue, String columnValue) async {
+    final existing = _findCell(rowValue, columnValue);
+    final mmController = TextEditingController(text: existing.mm ?? '');
+    final qtyController = TextEditingController(text: existing.qty.toString());
+    final notesController = TextEditingController(text: existing.notes ?? '');
+    var enabled = existing.enabled;
+    var requiresAccessory = existing.requiresAccessory;
+
+    final updated = await showDialog<ConnectorMatrixCell>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: Text('Edit $rowValue × $columnValue'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: mmController,
+                      decoration: const InputDecoration(labelText: 'Part number'),
+                    ),
+                    TextField(
+                      controller: qtyController,
+                      decoration: const InputDecoration(labelText: 'Quantity'),
+                      keyboardType: TextInputType.number,
+                    ),
+                    SwitchListTile(
+                      title: const Text('Combination enabled'),
+                      value: enabled,
+                      onChanged: (v) => setState(() => enabled = v),
+                    ),
+                    CheckboxListTile(
+                      value: requiresAccessory,
+                      onChanged: (v) => setState(() => requiresAccessory = v ?? false),
+                      title: const Text('Requires accessory'),
+                    ),
+                    TextField(
+                      controller: notesController,
+                      decoration: const InputDecoration(labelText: 'Notes'),
+                      maxLines: 2,
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    mmController.clear();
+                    qtyController.text = '1';
+                    notesController.clear();
+                    enabled = true;
+                    requiresAccessory = false;
+                    setState(() {});
+                  },
+                  child: const Text('Clear'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final qty = int.tryParse(qtyController.text.trim());
+                    Navigator.of(context).pop(
+                      ConnectorMatrixCell(
+                        axis2Value: columnValue,
+                        mm: mmController.text.trim().isEmpty
+                            ? null
+                            : mmController.text.trim(),
+                        qty: qty ?? 1,
+                        enabled: enabled,
+                        requiresAccessory: requiresAccessory,
+                        notes: notesController.text.trim().isEmpty
+                            ? null
+                            : notesController.text.trim(),
+                      ),
+                    );
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (updated != null) {
+      _setCell(rowValue, columnValue, updated);
+    }
+  }
+
+  String _matrixToCsv() {
+    final sb = StringBuffer();
+    final columns = _sortedColumns();
+    sb.writeln(
+        '${_csvEscape(_matrix.axis1Parameter.isEmpty ? 'axis1' : _matrix.axis1Parameter)},${_csvEscape(_matrix.axis2Parameter.isEmpty ? 'axis2' : _matrix.axis2Parameter)},mm,qty,enabled,requires_accessory,notes');
+    for (final row in _matrix.rows) {
+      for (final column in columns) {
+        final cell = _findCell(row.axis1Value, column);
+        final line = [
+          _csvEscape(row.axis1Value),
+          _csvEscape(column),
+          _csvEscape(cell.mm ?? ''),
+          _csvEscape(cell.qty.toString()),
+          _csvEscape(cell.enabled ? 'true' : 'false'),
+          _csvEscape(cell.requiresAccessory ? 'true' : 'false'),
+          _csvEscape(cell.notes ?? ''),
+        ].join(',');
+        sb.writeln(line);
+      }
+    }
+    return sb.toString();
+  }
+
+  void _importMatrixFromCsv(String csv) {
+    final trimmed = csv.trim();
+    if (trimmed.isEmpty) return;
+    final lines = const LineSplitter().convert(trimmed);
+    if (lines.isEmpty) return;
+    final rowsByAxis1 = <String, List<ConnectorMatrixCell>>{};
+    for (var i = 1; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (line.isEmpty) continue;
+      final parts = _splitCsvLine(line);
+      if (parts.length < 2) continue;
+      final axis1 = parts[0].trim();
+      final axis2 = parts[1].trim();
+      if (axis1.isEmpty || axis2.isEmpty) {
+        continue;
+      }
+      final mm = parts.length > 2 ? parts[2].trim() : '';
+      final qtyString = parts.length > 3 ? parts[3].trim() : '1';
+      final enabledString = parts.length > 4 ? parts[4].trim() : 'true';
+      final requiresAccessoryString =
+          parts.length > 5 ? parts[5].trim() : 'false';
+      final notes = parts.length > 6 ? parts[6].trim() : '';
+      final qty = int.tryParse(qtyString) ?? 1;
+      final enabled = enabledString.toLowerCase() != 'false';
+      final requiresAccessory = requiresAccessoryString.toLowerCase() == 'true';
+      rowsByAxis1.putIfAbsent(axis1, () => <ConnectorMatrixCell>[]).add(
+            ConnectorMatrixCell(
+              axis2Value: axis2,
+              mm: mm.isEmpty ? null : mm,
+              qty: qty,
+              enabled: enabled,
+              requiresAccessory: requiresAccessory,
+              notes: notes.isEmpty ? null : notes,
+            ),
+          );
+    }
+    final rows = <ConnectorMatrixRow>[];
+    for (final entry in rowsByAxis1.entries) {
+      entry.value.sort((a, b) =>
+          a.axis2Value.toLowerCase().compareTo(b.axis2Value.toLowerCase()));
+      rows.add(ConnectorMatrixRow(axis1Value: entry.key, cells: entry.value));
+    }
+    rows.sort((a, b) => a.axis1Value.toLowerCase().compareTo(b.axis1Value.toLowerCase()));
+    _updateMatrix(_matrix.copyWith(rows: rows));
+  }
+
+  void _showExportDialog() {
+    final csv = _matrixToCsv();
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Matrix CSV'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: SelectableText(csv),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showImportDialog() {
+    final controller = TextEditingController();
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Import matrix CSV'),
+        content: TextField(
+          controller: controller,
+          maxLines: 10,
+          decoration: const InputDecoration(
+            hintText: 'Paste CSV content here',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final text = controller.text.trim();
+              Navigator.of(context).pop();
+              if (text.isEmpty) return;
+              _importMatrixFromCsv(text);
+            },
+            child: const Text('Import'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _csvEscape(String value) {
+    if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+      final escaped = value.replaceAll('"', '""');
+      return '"$escaped"';
+    }
+    return value;
+  }
+
+  List<String> _splitCsvLine(String line) {
+    final values = <String>[];
+    final buffer = StringBuffer();
+    var inQuotes = false;
+    for (var i = 0; i < line.length; i++) {
+      final char = line[i];
+      if (char == '"') {
+        if (inQuotes && i + 1 < line.length && line[i + 1] == '"') {
+          buffer.write('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char == ',' && !inQuotes) {
+        values.add(buffer.toString());
+        buffer.clear();
+      } else {
+        buffer.write(char);
+      }
+    }
+    values.add(buffer.toString());
+    return values;
+  }
+
   void _finish() {
+    final matrix = _matrixForSave();
+    final pattern = _mmPatternController.text.trim();
     final updated = DynamicComponentDef(
       name: widget.component.name,
       selectionStrategy: widget.component.selectionStrategy,
       rules: List<RuleDef>.from(_rules),
+      matrix: matrix,
+      mmPattern: pattern.isEmpty ? null : pattern,
     );
     if (!mounted) return;
     Navigator.of(context).pop(updated);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final componentName =
+        widget.component.name.isEmpty ? 'Dynamic Component' : widget.component.name;
+
+    return DefaultTabController(
+      length: 2,
+      child: WillPopScope(
+        onWillPop: () async {
+          _finish();
+          return false;
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text('Rules — $componentName'),
+            actions: [
+              PopupMenuButton<String>(
+                onSelected: (value) {
+                  switch (value) {
+                    case 'import':
+                      _showImportDialog();
+                      break;
+                    case 'export':
+                      _showExportDialog();
+                      break;
+                  }
+                },
+                itemBuilder: (context) => const [
+                  PopupMenuItem(value: 'import', child: Text('Import matrix CSV')),
+                  PopupMenuItem(value: 'export', child: Text('Export matrix CSV')),
+                ],
+              ),
+              TextButton(
+                onPressed: _finish,
+                style: TextButton.styleFrom(
+                  foregroundColor: Colors.white,
+                ),
+                child: const Text('Done'),
+              ),
+            ],
+            bottom: const TabBar(
+              tabs: [
+                Tab(text: 'Matrix'),
+                Tab(text: 'Rules'),
+              ],
+            ),
+          ),
+          body: TabBarView(
+            children: [
+              _buildMatrixTab(),
+              _buildRulesTab(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMatrixTab() {
+    final columns = _sortedColumns();
+    final axis1Label =
+        _matrix.axis1Parameter.isEmpty ? 'First axis parameter key' : _matrix.axis1Parameter;
+    final axis2Label =
+        _matrix.axis2Parameter.isEmpty ? 'Second axis parameter key' : _matrix.axis2Parameter;
+    final axis1Display =
+        _matrix.axis1Parameter.isEmpty ? 'row' : _matrix.axis1Parameter;
+    final axis2Display =
+        _matrix.axis2Parameter.isEmpty ? 'column' : _matrix.axis2Parameter;
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Define wire combinations using the matrix. Each cell can hold a part number, quantity, notes, and whether the combo is allowed.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _axis1Controller,
+                  decoration: const InputDecoration(
+                    labelText: 'First axis parameter key',
+                    helperText: 'Matches a parameter in the job form (e.g., wire_1)',
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: TextField(
+                  controller: _axis2Controller,
+                  decoration: const InputDecoration(
+                    labelText: 'Second axis parameter key',
+                    helperText: 'Matches a parameter in the job form (e.g., wire_2)',
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _mmPatternController,
+            decoration: const InputDecoration(
+              labelText: 'Optional SKU pattern',
+              helperText: 'Use placeholders like {axis1}, {axis2}, or any parameter key.',
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              ElevatedButton.icon(
+                onPressed: _addAxis1Value,
+                icon: const Icon(Icons.table_rows),
+                label: Text('Add $axis1Display value'),
+              ),
+              ElevatedButton.icon(
+                onPressed: _addAxis2Value,
+                icon: const Icon(Icons.table_chart),
+                label: Text('Add $axis2Display value'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: _matrix.rows.isEmpty
+                ? Center(
+                    child: Text(
+                      'No combinations yet. Add $axis1Display values and $axis2Display values to begin.',
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : SingleChildScrollView(
+                    child: SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: DataTable(
+                        columns: [
+                          DataColumn(label: Text(axis1Label.isEmpty ? 'Row' : axis1Label)),
+                          for (final column in columns)
+                            DataColumn(
+                              label: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(column),
+                                  IconButton(
+                                    icon: const Icon(Icons.close, size: 16),
+                                    tooltip: 'Remove $column',
+                                    onPressed: () => _removeAxis2Value(column),
+                                  ),
+                                ],
+                              ),
+                            ),
+                        ],
+                        rows: [
+                          for (final row in _matrix.rows)
+                            DataRow(
+                              cells: [
+                                DataCell(
+                                  SizedBox(
+                                    width: 150,
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            row.axis1Value,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ),
+                                        IconButton(
+                                          icon: const Icon(Icons.close, size: 16),
+                                          tooltip: 'Remove ${row.axis1Value}',
+                                          onPressed: () => _removeAxis1Value(row.axis1Value),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                for (final column in columns)
+                                  _buildMatrixCell(row.axis1Value, column),
+                              ],
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  DataCell _buildMatrixCell(String rowValue, String columnValue) {
+    final cell = _findCell(rowValue, columnValue);
+    final content = <Widget>[];
+    if (!cell.enabled) {
+      content.add(const Icon(Icons.block, size: 18, color: Colors.redAccent));
+    }
+    final mm = cell.mm;
+    if (mm != null && mm.isNotEmpty) {
+      content.add(Text(mm, style: const TextStyle(fontWeight: FontWeight.bold)));
+    }
+    if (cell.requiresAccessory) {
+      content.add(const Text('Accessory required', style: TextStyle(fontSize: 11)));
+    }
+    if (cell.notes != null && cell.notes!.isNotEmpty) {
+      content.add(Text(cell.notes!, style: const TextStyle(fontSize: 11)));
+    }
+    if (content.isEmpty) {
+      content.add(const Text('—', style: TextStyle(color: Colors.grey)));
+    }
+    return DataCell(
+      InkWell(
+        onTap: () => _editCell(rowValue, columnValue),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: content,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRulesTab() {
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: _rules.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('No advanced rules defined yet.'),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    onPressed: _addRule,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add rule'),
+                  ),
+                ],
+              ),
+            )
+          : ListView(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: ElevatedButton.icon(
+                    onPressed: _addRule,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add rule'),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                for (final entry in _rules.asMap().entries)
+                  Card(
+                    margin: const EdgeInsets.symmetric(vertical: 6),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Rule ${entry.key + 1}',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 4),
+                          Text('Priority: ${entry.value.priority}'),
+                          const SizedBox(height: 4),
+                          Text('When: ${_exprSummary(entry.value.expr)}'),
+                          const SizedBox(height: 4),
+                          Text('Outputs: ${_outputsSummary(entry.value.outputs)}'),
+                          ButtonBar(
+                            alignment: MainAxisAlignment.end,
+                            children: [
+                              TextButton(
+                                onPressed: () => _editRule(entry.key),
+                                child: const Text('Edit'),
+                              ),
+                              TextButton(
+                                onPressed: () => _deleteRule(entry.key),
+                                child: const Text('Delete'),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+    );
   }
 
   String _exprSummary(Map<String, dynamic> expr) {
@@ -104,95 +898,5 @@ class _DynamicComponentRulesScreenState
       }
       return buffer.toString();
     }).join(', ');
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final componentName =
-        widget.component.name.isEmpty ? 'Dynamic Component' : widget.component.name;
-
-    return WillPopScope(
-      onWillPop: () async {
-        _finish();
-        return false;
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text('Rules — $componentName'),
-          actions: [
-            TextButton(
-              onPressed: _finish,
-              style: TextButton.styleFrom(
-                foregroundColor: Colors.white,
-              ),
-              child: const Text('Done'),
-            ),
-          ],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(12),
-          child: _rules.isEmpty
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Text('No rules defined yet.'),
-                      const SizedBox(height: 8),
-                      TextButton.icon(
-                        onPressed: _addRule,
-                        icon: const Icon(Icons.add),
-                        label: const Text('Add Rule'),
-                      ),
-                    ],
-                  ),
-                )
-              : ListView(
-                  children: [
-                    for (final entry in _rules.asMap().entries)
-                      Card(
-                        margin: const EdgeInsets.symmetric(vertical: 6),
-                        child: Padding(
-                          padding: const EdgeInsets.all(12),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Rule ${entry.key + 1}',
-                                style: Theme.of(context).textTheme.titleMedium,
-                              ),
-                              const SizedBox(height: 4),
-                              Text('Priority: ${entry.value.priority}'),
-                              const SizedBox(height: 4),
-                              Text('When: ${_exprSummary(entry.value.expr)}'),
-                              const SizedBox(height: 4),
-                              Text('Outputs: ${_outputsSummary(entry.value.outputs)}'),
-                              ButtonBar(
-                                alignment: MainAxisAlignment.end,
-                                children: [
-                                  TextButton(
-                                    onPressed: () => _editRule(entry.key),
-                                    child: const Text('Edit'),
-                                  ),
-                                  TextButton(
-                                    onPressed: () => _deleteRule(entry.key),
-                                    child: const Text('Delete'),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-        ),
-        floatingActionButton: _rules.isEmpty
-            ? null
-            : FloatingActionButton(
-                onPressed: _addRule,
-                child: const Icon(Icons.add),
-              ),
-      ),
-    );
   }
 }

--- a/lib/ui/new_job_screen.dart
+++ b/lib/ui/new_job_screen.dart
@@ -93,11 +93,39 @@ class _NewJobScreenState extends State<NewJobScreen> {
             Expanded(
               child: ListView.builder(
                 itemCount: bom.length,
-                itemBuilder: (_, i) => ListTile(
-                  dense: true,
-                  title: Text('${bom[i].mm}  × ${bom[i].qty}'),
-                  subtitle: Text(bom[i].source),
-                ),
+                itemBuilder: (_, i) {
+                  final line = bom[i];
+                  final notes = <Widget>[
+                    Text(line.source),
+                  ];
+                  if (line.status != 'ok') {
+                    notes.add(
+                      Text(
+                        'Status: ${line.status}',
+                        style: const TextStyle(color: Colors.redAccent),
+                      ),
+                    );
+                  }
+                  if (line.requiresAccessory) {
+                    notes.add(
+                      const Text(
+                        'Requires accessory',
+                        style: TextStyle(fontStyle: FontStyle.italic),
+                      ),
+                    );
+                  }
+                  if (line.notes != null && line.notes!.trim().isNotEmpty) {
+                    notes.add(Text(line.notes!));
+                  }
+                  return ListTile(
+                    dense: true,
+                    title: Text('${line.mm}  × ${line.qty}'),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: notes,
+                    ),
+                  );
+                },
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- add connector matrix metadata and SKU pattern support to dynamic components and BOM lines
- extend the rule engine and job view to use matrix selections, flag invalid combos, and surface accessory notes
- replace the rule editor screen with a matrix authoring UI that supports CSV import/export alongside existing rule tools and add engine coverage tests

## Testing
- not run (flutter/dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d442660e4c8326a0f365305102ca22