### PR TITLE
Fix dynamic component editing and add parameter suggestions

### DIFF
--- a/lib/ui/global_parameters_screen.dart
+++ b/lib/ui/global_parameters_screen.dart
@@ -368,6 +368,11 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
                                       onChanged: (p) =>
                                           _onParameterChanged(entry.key, p),
                                       onDelete: () => _removeParameter(entry.key),
+                                      keySuggestions: parameters
+                                          .map((p) => p.key.trim())
+                                          .where((k) => k.isNotEmpty)
+                                          .toSet()
+                                          .toList(),
                                     ),
                                   );
                                 },

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -595,6 +595,13 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
             ),
           )
           .toList(),
+      matrix: source.matrix == null
+          ? null
+          : ConnectorMatrix.fromJson(
+              (jsonDecode(jsonEncode(source.matrix!.toJson())) as Map)
+                  .cast<String, dynamic>(),
+            ),
+      mmPattern: source.mmPattern,
     );
   }
 
@@ -1097,6 +1104,17 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                     def: e.value,
                     onChanged: (p) => _onParameterChanged(e.key, p),
                     onDelete: () => _removeParameterAt(e.key),
+                    keySuggestions: () {
+                      final suggestions = <String>{
+                        ...globalParameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                        ...parameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                      };
+                      return suggestions.toList();
+                    }(),
                   ),
                 )
                 .toList(),
@@ -1165,6 +1183,8 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                         name: name,
                         selectionStrategy: old.selectionStrategy,
                         rules: old.rules,
+                        matrix: old.matrix,
+                        mmPattern: old.mmPattern,
                       );
                       _combineGlobalDynamicComponents();
                     }),


### PR DESCRIPTION
## Summary
- preserve dynamic component rule, matrix, and pattern data when cloning or renaming so existing configurations load correctly in the editor
- enable exporting the connector matrix directly to a CSV file using the native save dialog instead of only showing the raw text
- add autocomplete suggestions for parameter keys sourced from existing global parameters when editing parameters

## Testing
- Not run (Flutter tooling is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68d44be3dbbc8326aed7cc021eba77e5