### PR TITLE
Fix dynamic component editing and add parameter suggestions

### DIFF
--- a/lib/ui/dynamic_component_rules_screen.dart
+++ b/lib/ui/dynamic_component_rules_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 
 import '../core/models.dart';
@@ -484,24 +486,39 @@ class _DynamicComponentRulesScreenState
     _updateMatrix(_matrix.copyWith(rows: rows));
   }
 
-  void _showExportDialog() {
+  Future<void> _exportMatrixCsv() async {
     final csv = _matrixToCsv();
-    showDialog<void>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Matrix CSV'),
-        content: SizedBox(
-          width: double.maxFinite,
-          child: SelectableText(csv),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Close'),
+    final suggestedName = _suggestedMatrixFilename();
+    try {
+      final location = await getSaveLocation(
+        suggestedName: suggestedName,
+        acceptedTypeGroups: const [
+          XTypeGroup(
+            label: 'CSV',
+            extensions: ['csv'],
           ),
         ],
-      ),
-    );
+      );
+      final path = location?.path;
+      if (path == null) {
+        return;
+      }
+      final file = XFile.fromData(
+        Uint8List.fromList(utf8.encode(csv)),
+        mimeType: 'text/csv',
+        name: suggestedName,
+      );
+      await file.saveTo(path);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Matrix exported to $path')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to export matrix: $e')),
+      );
+    }
   }
 
   void _showImportDialog() {
@@ -605,7 +622,7 @@ class _DynamicComponentRulesScreenState
                       _showImportDialog();
                       break;
                     case 'export':
-                      _showExportDialog();
+                      _exportMatrixCsv();
                       break;
                   }
                 },
@@ -898,5 +915,13 @@ class _DynamicComponentRulesScreenState
       }
       return buffer.toString();
     }).join(', ');
+  }
+
+  String _suggestedMatrixFilename() {
+    final name = widget.component.name.trim();
+    final sanitized = name.isEmpty
+        ? 'dynamic_component_matrix'
+        : name.replaceAll(RegExp(r'[^A-Za-z0-9_\-]+'), '_');
+    return '$sanitized.csv';
   }
 }

--- a/lib/ui/global_parameters_screen.dart
+++ b/lib/ui/global_parameters_screen.dart
@@ -368,6 +368,11 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
                                       onChanged: (p) =>
                                           _onParameterChanged(entry.key, p),
                                       onDelete: () => _removeParameter(entry.key),
+                                      keySuggestions: parameters
+                                          .map((p) => p.key.trim())
+                                          .where((k) => k.isNotEmpty)
+                                          .toSet()
+                                          .toList(),
                                     ),
                                   );
                                 },

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -595,6 +595,13 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
             ),
           )
           .toList(),
+      matrix: source.matrix == null
+          ? null
+          : ConnectorMatrix.fromJson(
+              (jsonDecode(jsonEncode(source.matrix!.toJson())) as Map)
+                  .cast<String, dynamic>(),
+            ),
+      mmPattern: source.mmPattern,
     );
   }
 
@@ -1097,6 +1104,17 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                     def: e.value,
                     onChanged: (p) => _onParameterChanged(e.key, p),
                     onDelete: () => _removeParameterAt(e.key),
+                    keySuggestions: () {
+                      final suggestions = <String>{
+                        ...globalParameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                        ...parameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                      };
+                      return suggestions.toList();
+                    }(),
                   ),
                 )
                 .toList(),
@@ -1165,6 +1183,8 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                         name: name,
                         selectionStrategy: old.selectionStrategy,
                         rules: old.rules,
+                        matrix: old.matrix,
+                        mmPattern: old.mmPattern,
                       );
                       _combineGlobalDynamicComponents();
                     }),


### PR DESCRIPTION
## Summary
- preserve dynamic component rule, matrix, and pattern data when cloning or renaming so existing configurations load correctly in the editor
- enable exporting the connector matrix directly to a CSV file using the native save dialog via the compatible file_selector `getSaveLocation` API instead of only showing the raw text
- add autocomplete suggestions for parameter keys sourced from existing global parameters when editing parameters

## Testing
- `flutter test` *(fails: existing suite has mismatches in local_repo_test expectations, undefined FlaggedMaterialConflictType, and pumpAndSettle timeouts in screen widget tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d44be3dbbc8326aed7cc021eba77e5