### PR TITLE
Preserve dynamic matrices and add axis parameter autocomplete

### DIFF
--- a/lib/ui/global_dynamic_components_screen.dart
+++ b/lib/ui/global_dynamic_components_screen.dart
@@ -90,6 +90,8 @@ class _GlobalDynamicComponentsScreenState
         name: value,
         selectionStrategy: old.selectionStrategy,
         rules: old.rules,
+        matrix: old.matrix,
+        mmPattern: old.mmPattern,
       );
     });
   }
@@ -155,11 +157,16 @@ class _GlobalDynamicComponentsScreenState
           );
           return;
         }
+        final trimmedPattern = c.mmPattern?.trim();
         cleaned.add(
           DynamicComponentDef(
             name: name,
             selectionStrategy: c.selectionStrategy,
             rules: c.rules,
+            matrix: c.matrix,
+            mmPattern: trimmedPattern == null || trimmedPattern.isEmpty
+                ? null
+                : trimmedPattern,
           ),
         );
       }

--- a/lib/ui/global_parameters_screen.dart
+++ b/lib/ui/global_parameters_screen.dart
@@ -368,6 +368,11 @@ class _GlobalParametersScreenState extends State<GlobalParametersScreen> {
                                       onChanged: (p) =>
                                           _onParameterChanged(entry.key, p),
                                       onDelete: () => _removeParameter(entry.key),
+                                      keySuggestions: parameters
+                                          .map((p) => p.key.trim())
+                                          .where((k) => k.isNotEmpty)
+                                          .toSet()
+                                          .toList(),
                                     ),
                                   );
                                 },

--- a/lib/ui/standards_manager_screen.dart
+++ b/lib/ui/standards_manager_screen.dart
@@ -595,6 +595,13 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
             ),
           )
           .toList(),
+      matrix: source.matrix == null
+          ? null
+          : ConnectorMatrix.fromJson(
+              (jsonDecode(jsonEncode(source.matrix!.toJson())) as Map)
+                  .cast<String, dynamic>(),
+            ),
+      mmPattern: source.mmPattern,
     );
   }
 
@@ -619,7 +626,7 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
         MaterialPageRoute(
           builder: (_) => DynamicComponentRulesScreen(
             component: dynamicComponents[index],
-            parameters: parameters,
+            parameters: globalParameters,
           ),
         ),
       );
@@ -710,11 +717,16 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
           );
           return;
         }
+        final trimmedPattern = c.mmPattern?.trim();
         cleanedDynamic.add(
           DynamicComponentDef(
             name: nameValue,
             selectionStrategy: c.selectionStrategy,
             rules: c.rules,
+            matrix: c.matrix,
+            mmPattern: trimmedPattern == null || trimmedPattern.isEmpty
+                ? null
+                : trimmedPattern,
           ),
         );
       }
@@ -1097,6 +1109,17 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                     def: e.value,
                     onChanged: (p) => _onParameterChanged(e.key, p),
                     onDelete: () => _removeParameterAt(e.key),
+                    keySuggestions: () {
+                      final suggestions = <String>{
+                        ...globalParameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                        ...parameters
+                            .map((p) => p.key.trim())
+                            .where((k) => k.isNotEmpty),
+                      };
+                      return suggestions.toList();
+                    }(),
                   ),
                 )
                 .toList(),
@@ -1165,6 +1188,8 @@ class _StandardDetailScreenState extends State<_StandardDetailScreen> {
                         name: name,
                         selectionStrategy: old.selectionStrategy,
                         rules: old.rules,
+                        matrix: old.matrix,
+                        mmPattern: old.mmPattern,
                       );
                       _combineGlobalDynamicComponents();
                     }),


### PR DESCRIPTION
## Summary
- keep dynamic component matrices and SKU patterns when renaming or saving components from both the standards and global management flows so previously entered combinations remain intact
- pass the combined parameter list to the dynamic rules editor and surface RawAutocomplete suggestions for the axis parameter fields using the available global parameter keys

## Testing
- `flutter test` *(fails: Flutter tooling is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44be3dbbc8326aed7cc021eba77e5