### PR TITLE
Normalize matrix axis comparisons for numeric values

### DIFF
--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -172,6 +172,37 @@ void main() {
     expect(bom.single.source, 'matrix:Conn');
   });
 
+  test('matrix treats numeric axis values equivalently', () {
+    final std = StandardDef(
+      code: 'T',
+      name: 'Test',
+      parameters: [
+        ParameterDef(key: 'wire1', type: ParamType.number),
+        ParameterDef(key: 'wire2', type: ParamType.number),
+      ],
+      dynamicComponents: [
+        DynamicComponentDef(
+          name: 'Conn',
+          matrix: ConnectorMatrix(
+            axis1Parameter: 'wire1',
+            axis2Parameter: 'wire2',
+            rows: [
+              ConnectorMatrixRow(
+                axis1Value: '4',
+                cells: [ConnectorMatrixCell(axis2Value: '4', mm: 'MM#NUM')],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    final eng = RuleEngine();
+    final bomInt = eng.evaluate(std, {'wire1': 4, 'wire2': 4});
+    expect(bomInt.single.mm, 'MM#NUM');
+    final bomDouble = eng.evaluate(std, {'wire1': 4.0, 'wire2': 4.0});
+    expect(bomDouble.single.mm, 'MM#NUM');
+  });
+
   test('matrix marks missing combination as invalid', () {
     final std = StandardDef(
       code: 'T',


### PR DESCRIPTION
## Summary
- normalize connector matrix axis comparisons so numeric inputs like `4` and `4.0` resolve to the same cell
- canonicalize value stringification to avoid dangling decimal zeros and compare tokens case-insensitively
- add regression test covering numeric axis matching for matrices

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d45fa04804832699c5ab3627dbfa03