### PR TITLE
Allow dynamic matrix cells to specify multiple part numbers

### DIFF
--- a/lib/data/local_repo.dart
+++ b/lib/data/local_repo.dart
@@ -1329,7 +1329,11 @@ String _canonicalMatrixString(ConnectorMatrix? matrix) {
             final map = <String, dynamic>{
               'axis2_value': cell.axis2Value,
             };
-            if (cell.mm != null) map['mm'] = cell.mm;
+            if (cell.mms.length == 1) {
+              map['mm'] = cell.mms.first;
+            } else if (cell.mms.isNotEmpty) {
+              map['mms'] = cell.mms;
+            }
             if (cell.qty != 1) map['qty'] = cell.qty;
             if (!cell.enabled) map['enabled'] = cell.enabled;
             if (cell.requiresAccessory) {

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -273,6 +273,43 @@ void main() {
     expect(line.notes, 'Use reducer sleeve');
   });
 
+  test('matrix emits multiple BOM lines when multiple SKUs are provided', () {
+    final std = StandardDef(
+      code: 'T',
+      name: 'Test',
+      parameters: [
+        ParameterDef(key: 'wire1', type: ParamType.enumType, allowedValues: ['1/0']),
+        ParameterDef(key: 'wire2', type: ParamType.enumType, allowedValues: ['2/0']),
+      ],
+      dynamicComponents: [
+        DynamicComponentDef(
+          name: 'Conn',
+          matrix: ConnectorMatrix(
+            axis1Parameter: 'wire1',
+            axis2Parameter: 'wire2',
+            rows: [
+              ConnectorMatrixRow(
+                axis1Value: '1/0',
+                cells: [
+                  ConnectorMatrixCell(
+                    axis2Value: '2/0',
+                    mms: ['MM#1200', 'MM#1201'],
+                    qty: 2,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    final eng = RuleEngine();
+    final bom = eng.evaluate(std, {'wire1': '1/0', 'wire2': '2/0'});
+    expect(bom, hasLength(2));
+    expect(bom.map((line) => line.mm), ['MM#1200', 'MM#1201']);
+    expect(bom.every((line) => line.qty == 2), isTrue);
+  });
+
   test('matrix falls back to rules when no SKU is provided', () {
     final std = StandardDef(
       code: 'T',


### PR DESCRIPTION
## Summary
- allow connector matrix cells to capture multiple manual MM numbers and persist them
- update the rule engine to emit BOM lines for each matrix MM while keeping fallbacks working
- expand the matrix editor UI and CSV handling plus tests to cover the new behaviour

## Testing
- flutter test *(fails locally: Flutter SDK not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53588f11c8326add0cdfec88ff702