### PR TITLE
Add duplicate action and deep-clone for dynamic component rules

### DIFF
--- a/lib/ui/dynamic_component_rules_screen.dart
+++ b/lib/ui/dynamic_component_rules_screen.dart
@@ -257,6 +257,44 @@ class _DynamicComponentRulesScreenState
     }
   }
 
+  RuleDef _cloneRule(RuleDef source) {
+    return RuleDef(
+      expr: (jsonDecode(jsonEncode(source.expr)) as Map).cast<String, dynamic>(),
+      outputs: source.outputs
+          .map(
+            (output) => OutputSpec(
+              mm: output.mm,
+              qty: output.qty,
+              qtyFormula: output.qtyFormula,
+            ),
+          )
+          .toList(),
+      priority: source.priority,
+    );
+  }
+
+  Future<void> _duplicateRule(int index) async {
+    final clonedRule = _cloneRule(_rules[index]);
+    final duplicated = await Navigator.of(context).push<RuleDef>(
+      MaterialPageRoute(
+        builder: (_) => RuleWizard(
+          existing: clonedRule,
+          parameters: widget.parameters,
+        ),
+      ),
+    );
+    if (duplicated != null) {
+      setState(() {
+        _rules.add(duplicated);
+        _sortRules();
+      });
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Rule duplicated')),
+      );
+    }
+  }
+
   void _deleteRule(int index) {
     setState(() {
       _rules.removeAt(index);
@@ -999,6 +1037,10 @@ class _DynamicComponentRulesScreenState
                               TextButton(
                                 onPressed: () => _editRule(entry.key),
                                 child: const Text('Edit'),
+                              ),
+                              TextButton(
+                                onPressed: () => _duplicateRule(entry.key),
+                                child: const Text('Duplicate'),
                               ),
                               TextButton(
                                 onPressed: () => _deleteRule(entry.key),

--- a/test/dynamic_component_rules_screen_test.dart
+++ b/test/dynamic_component_rules_screen_test.dart
@@ -1,0 +1,78 @@
+import 'package:bom_builder/core/models.dart';
+import 'package:bom_builder/ui/dynamic_component_rules_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  DynamicComponentDef buildComponent() {
+    return DynamicComponentDef(
+      name: 'Test Component',
+      rules: [
+        RuleDef(
+          expr: {
+            '==': [
+              {'var': 'voltage'},
+              120,
+            ],
+          },
+          outputs: [
+            OutputSpec(mm: 'MM-1', qty: 2),
+          ],
+          priority: 10,
+        ),
+      ],
+    );
+  }
+
+  List<ParameterDef> buildParameters() {
+    return [
+      ParameterDef(key: 'voltage', type: ParamType.number),
+    ];
+  }
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DynamicComponentRulesScreen(
+          component: buildComponent(),
+          parameters: buildParameters(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows duplicate action on each rule card', (tester) async {
+    await pumpScreen(tester);
+
+    expect(find.widgetWithText(TextButton, 'Duplicate'), findsOneWidget);
+  });
+
+  testWidgets('duplicating a rule creates a second rule with same initial content', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Duplicate'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rule duplicated'), findsOneWidget);
+    expect(find.text('Outputs: MM-1 × 2'), findsNWidgets(2));
+    expect(find.text('When: voltage == 120'), findsNWidgets(2));
+  });
+
+  testWidgets('editing duplicated rule updates only duplicated entry', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Duplicate'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.widgetWithText(TextField, 'Priority'), '5');
+    await tester.tap(find.widgetWithText(TextButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Priority: 10'), findsOneWidget);
+    expect(find.text('Priority: 5'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Allow users to quickly duplicate an existing rule so they can adjust a copy without mutating the original.
- Ensure duplicates are deep copies so nested `expr` and `outputs` are independent from the source rule.

### Description
- Added a helper `RuleDef _cloneRule(RuleDef source)` that deep-copies `expr` via a JSON round-trip, clones each `OutputSpec`, and preserves `priority`.
- Added `_duplicateRule(int index)` which clones the selected rule, opens `RuleWizard(existing: clonedRule, parameters: widget.parameters)`, and on save appends the new rule and calls `_sortRules()`.
- Inserted a `Duplicate` `TextButton` into each rule card's `ButtonBar`, positioned between `Edit` and `Delete`.
- Added a snackbar confirmation (`Rule duplicated`) after a duplicate is saved and added widget tests under `test/dynamic_component_rules_screen_test.dart` covering button visibility, duplicate flow, and editing behavior.

### Testing
- Added widget tests: `shows duplicate action on each rule card`, `duplicating a rule creates a second rule with same initial content`, and `editing duplicated rule updates only duplicated entry` in `test/dynamic_component_rules_screen_test.dart`.
- Attempted to run `flutter test test/dynamic_component_rules_screen_test.dart` but the environment lacks the `flutter` tool so tests were not executed (`/bin/bash: line 1: flutter: command not found`).
- Manual UI runs were not performed in this environment; the change is limited to UI logic and test additions and does not modify serialization format (`_finish()`/save logic unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5133bf02883268ea08cd4457af6fd)