### PR TITLE
Emit outputs from all matching dynamic rules

### DIFF
--- a/lib/core/engine.dart
+++ b/lib/core/engine.dart
@@ -17,16 +17,16 @@ class RuleEngine {
       dynamicByName[name] = dc;
     }
 
-    final selectedRules = <DynamicComponentDef, RuleDef?>{};
+    final selectedRules = <DynamicComponentDef, List<RuleDef>>{};
     final matrixSelections = <DynamicComponentDef, _MatrixSelection>{};
 
-    RuleDef? selectRule(DynamicComponentDef dc) {
+    List<RuleDef> selectRules(DynamicComponentDef dc) {
       if (selectedRules.containsKey(dc)) {
-        return selectedRules[dc];
+        return selectedRules[dc]!;
       }
-      final rule = _selectRule(dc, inputs);
-      selectedRules[dc] = rule;
-      return rule;
+      final rules = _selectRules(dc, inputs);
+      selectedRules[dc] = rules;
+      return rules;
     }
 
     _MatrixSelection matrixSelection(DynamicComponentDef dc) {
@@ -45,7 +45,7 @@ class RuleEngine {
             mm = matrixResult.primaryMm;
           }
         }
-        mm ??= provider != null ? _firstNonEmptyMm(selectRule(provider)) : null;
+        mm ??= provider != null ? _firstNonEmptyMm(selectRules(provider)) : null;
         if (mm != null) {
           bom.add(
             BomLine(
@@ -96,23 +96,25 @@ class RuleEngine {
       if (matrixResult.blockRules) {
         continue;
       }
-      final chosen = selectRule(dc);
-      if (chosen == null) continue;
-      for (final out in chosen.outputs) {
-        final qty = out.qty ?? QtyFormula.evalInt(out.qtyFormula ?? '1', numericInputs);
-        bom.add(BomLine(mm: out.mm, qty: qty, source: 'rule:${dc.name}'));
+      final chosen = selectRules(dc);
+      if (chosen.isEmpty) continue;
+      for (final rule in chosen) {
+        for (final out in rule.outputs) {
+          final qty = out.qty ?? QtyFormula.evalInt(out.qtyFormula ?? '1', numericInputs);
+          bom.add(BomLine(mm: out.mm, qty: qty, source: 'rule:${dc.name}'));
+        }
       }
     }
     return bom;
   }
 
-  RuleDef? _selectRule(DynamicComponentDef dc, Map<String, dynamic> inputs) {
+  List<RuleDef> _selectRules(DynamicComponentDef dc, Map<String, dynamic> inputs) {
     final matches = <RuleDef>[];
     for (final r in dc.rules) {
       final ok = _logic.apply(r.expr, inputs);
       if (ok == true) matches.add(r);
     }
-    if (matches.isEmpty) return null;
+    if (matches.isEmpty) return const [];
 
     matches.sort((a, b) {
       final p = (b.priority) - (a.priority);
@@ -122,14 +124,15 @@ class RuleEngine {
       return lb - la; // more specific first
     });
 
-    return matches.first;
+    return matches;
   }
 
-  String? _firstNonEmptyMm(RuleDef? rule) {
-    if (rule == null) return null;
-    for (final out in rule.outputs) {
-      final mm = out.mm.trim();
-      if (mm.isNotEmpty) return mm;
+  String? _firstNonEmptyMm(List<RuleDef> rules) {
+    for (final rule in rules) {
+      for (final out in rule.outputs) {
+        final mm = out.mm.trim();
+        if (mm.isNotEmpty) return mm;
+      }
     }
     return null;
   }

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -41,7 +41,7 @@ void main() {
     expect(bom.single.qty, 2);
   });
 
-  test('priority and specificity choose the right rule', () {
+  test('all matching rules emit outputs in priority/specificity order', () {
     final std = StandardDef(
       id: _uuid.v4(),
       code: 'T', name: 'Test',
@@ -55,7 +55,51 @@ void main() {
     );
     final eng = RuleEngine();
     final bom = eng.evaluate(std, {'PoleHeight': 35});
-    expect(bom.single.mm, 'MM#MID');
+    expect(bom, hasLength(2));
+    expect(bom.map((line) => line.mm), ['MM#MID', 'MM#LOW']);
+  });
+
+  test('all matching rules emit all outputs', () {
+    final std = StandardDef(
+      id: _uuid.v4(),
+      code: 'T',
+      name: 'Test',
+      parameters: [ParameterDef(key: 'wire', type: ParamType.enumType, allowedValues: ['2/0'])],
+      dynamicComponents: [
+        DynamicComponentDef(
+          name: 'Conn',
+          rules: [
+            RuleDef(
+              priority: 1,
+              expr: {
+                '==': [
+                  {'var': 'wire'},
+                  '2/0',
+                ],
+              },
+              outputs: [OutputSpec(mm: 'MM#A', qty: 1)],
+            ),
+            RuleDef(
+              priority: 0,
+              expr: {
+                'in': [
+                  {'var': 'wire'},
+                  ['1/0', '2/0'],
+                ],
+              },
+              outputs: [OutputSpec(mm: 'MM#B', qty: 2)],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final eng = RuleEngine();
+    final bom = eng.evaluate(std, {'wire': '2/0'});
+
+    expect(bom, hasLength(2));
+    expect(bom.map((line) => line.mm), ['MM#A', 'MM#B']);
+    expect(bom.map((line) => line.qty), [1, 2]);
   });
 
   test('qty formula computes simple arithmetic', () {
@@ -120,6 +164,63 @@ void main() {
         (line) =>
             line.source == 'static:Conn' &&
             line.mm == 'MM#SMALL' &&
+            line.qty == 5 &&
+            line.label == 'Brace',
+      ),
+      isTrue,
+    );
+  });
+
+  test('static component borrows first non-empty MM across all matching provider rules', () {
+    final std = StandardDef(
+      id: _uuid.v4(),
+      code: 'T',
+      name: 'Test',
+      staticComponents: [
+        StaticComponent(
+          label: 'Brace',
+          mm: 'MM#FALLBACK',
+          dynamicMmComponent: 'Conn',
+          qty: 5,
+        ),
+      ],
+      dynamicComponents: [
+        DynamicComponentDef(
+          name: 'Conn',
+          rules: [
+            RuleDef(
+              priority: 1,
+              expr: {
+                '==': [
+                  {'var': 'size'},
+                  'small',
+                ],
+              },
+              outputs: [OutputSpec(mm: '   ', qty: 1)],
+            ),
+            RuleDef(
+              priority: 0,
+              expr: {
+                'in': [
+                  {'var': 'size'},
+                  ['small', 'medium'],
+                ],
+              },
+              outputs: [OutputSpec(mm: 'MM#BORROWED', qty: 1)],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final eng = RuleEngine();
+    final bom = eng.evaluate(std, {'size': 'small'});
+
+    expect(
+      bom.any(
+        (line) =>
+            line.source == 'static:Conn' &&
+            line.mm == 'MM#BORROWED' &&
             line.qty == 5 &&
             line.label == 'Brace',
       ),
@@ -395,4 +496,3 @@ void main() {
     expect(bom.single.source, 'rule:Conn');
   });
 }
-


### PR DESCRIPTION
### Motivation
- Allow rule evaluation to return and apply multiple matching rules per dynamic component so every matching rule can contribute BOM outputs instead of only the top match.
- Preserve the existing matching/filtering semantics and deterministic ordering (priority descending, then expression specificity descending) while expanding emission behavior.
- Ensure static components that borrow MM from dynamic providers consider the full ordered rule list when selecting the first non-empty MM.

### Description
- Replaced the single-rule selector with multi-rule logic by changing the cache type from `Map<DynamicComponentDef, RuleDef?>` to `Map<DynamicComponentDef, List<RuleDef>>` and renaming helper functions from `_selectRule`/`_selectRule` to `selectRules`/`_selectRules` with the same filtering and sorting logic.
- Updated dynamic BOM emission to iterate over every selected rule and then each `OutputSpec` in that rule, adding a `BomLine` for each output in order.
- Changed static MM borrowing helper from `_firstNonEmptyMm(RuleDef?)` to `_firstNonEmptyMm(List<RuleDef>)` so it scans the ordered matches and returns the first non-empty output MM.
- Adjusted and added unit tests in `test/engine_test.dart` to cover multi-rule emission and the static-MM borrowing regression, and updated the priority/specificity test to assert ordering when multiple matches emit.

### Testing
- Added tests: `all matching rules emit outputs in priority/specificity order`, `all matching rules emit all outputs`, and `static component borrows first non-empty MM across all matching provider rules` in `test/engine_test.dart` and they are present for CI to run.
- Attempted to run `flutter test test/engine_test.dart` but the `flutter` tool is not available in this environment, so the test run did not execute.
- Attempted to run `dart test test/engine_test.dart` but the `dart` tool is not available in this environment, so the test run did not execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e21945248326a0f5987b16d0fc3e)